### PR TITLE
Minor cleanups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-on: 
+on:
   - push
   - pull_request
 
@@ -17,9 +17,10 @@ jobs:
         with:
           command: fmt
           argument: -- --check
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/clippy-check@v1
         with:
-          command: clippy
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: -- -D warnings
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/src/impl_/cell.rs
+++ b/src/impl_/cell.rs
@@ -160,7 +160,6 @@ impl<A:Send+'static> Cell<A> {
                                 is_first
                             });
                         if is_first {
-                            let c = c.clone();
                             sodium_ctx.post(move || {
                                 c.with_data(|data: &mut CellData<A>| {
                                     let mut next_value_op: Option<A> = None;
@@ -370,7 +369,7 @@ impl<A:Send+'static> Cell<A> {
             &sodium_ctx,
             |sa: StreamWeakForwardRef<A>| {
                 let inner_s: Arc<Mutex<WeakStream<A>>> = Arc::new(Mutex::new(Stream::downgrade(&csa.sample())));
-                let sa = sa.clone();
+                let sa = sa;
                 let node1: Node;
                 {
                     let inner_s = inner_s.clone();
@@ -422,7 +421,7 @@ impl<A:Send+'static> Cell<A> {
                     );
                 }
                 IsNode::add_update_dependencies(&node2, vec![csa_updates_dep, Dep::new(node1.gc_node().clone())]);
-                IsNode::add_dependency(&node1, node2.clone());
+                IsNode::add_dependency(&node1, node2);
                 node1
             }
         )
@@ -498,7 +497,7 @@ impl<A:Send+'static> Cell<A> {
                     *update = Box::new(node1_update);
                 }
                 {
-                    let last_inner_s = last_inner_s.clone();
+                    let last_inner_s = last_inner_s;
                     let node2_update = move || {
                         let l = last_inner_s.lock();
                         let last_inner_s: &WeakStream<A> = l.as_ref().unwrap();

--- a/src/impl_/cell.rs
+++ b/src/impl_/cell.rs
@@ -180,7 +180,7 @@ impl<A:Send+'static> Cell<A> {
         }
         let c = Cell {
             data: cell_data,
-            node: node
+            node
         };
         c_forward_ref.assign(&c);
         c

--- a/src/impl_/cell.rs
+++ b/src/impl_/cell.rs
@@ -423,7 +423,7 @@ impl<A:Send+'static> Cell<A> {
                 }
                 IsNode::add_update_dependencies(&node2, vec![csa_updates_dep, Dep::new(node1.gc_node().clone())]);
                 IsNode::add_dependency(&node1, node2.clone());
-                return node1;
+                node1
             }
         )
     }

--- a/src/impl_/cell_loop.rs
+++ b/src/impl_/cell_loop.rs
@@ -36,7 +36,7 @@ impl<A:Send+Clone+'static> CellLoop<A> {
                 let mut result_op: Option<A> = None;
                 mem::swap(&mut result_op, init_value_op);
                 if let Some(init_value) = result_op {
-                    return init_value.clone();
+                    return init_value;
                 }
                 panic!("CellLoop sampled before looped.");
             });
@@ -46,7 +46,7 @@ impl<A:Send+Clone+'static> CellLoop<A> {
         CellLoop {
             init_value_op,
             stream_loop,
-            cell: stream.hold_lazy(init_value.clone()),
+            cell: stream.hold_lazy(init_value),
         }
     }
 

--- a/src/impl_/cell_loop.rs
+++ b/src/impl_/cell_loop.rs
@@ -44,8 +44,8 @@ impl<A:Send+Clone+'static> CellLoop<A> {
         let stream_loop = StreamLoop::new(sodium_ctx);
         let stream = stream_loop.stream();
         CellLoop {
-            init_value_op: init_value_op,
-            stream_loop: stream_loop,
+            init_value_op,
+            stream_loop,
             cell: stream.hold_lazy(init_value.clone()),
         }
     }

--- a/src/impl_/gc_node.rs
+++ b/src/impl_/gc_node.rs
@@ -49,6 +49,12 @@ struct GcCtxData {
     to_be_freed: Vec<GcNode>
 }
 
+impl Default for GcCtx {
+    fn default() -> GcCtx {
+        GcCtx::new()
+    }
+}
+
 impl GcCtx {
     pub fn new() -> GcCtx {
         GcCtx {

--- a/src/impl_/gc_node.rs
+++ b/src/impl_/gc_node.rs
@@ -132,7 +132,7 @@ impl GcCtx {
         trace!("end: mark_roots");
     }
 
-    fn display_graph(&self, roots: &Vec<GcNode>) {
+    fn display_graph(&self, roots: &[GcNode]) {
         let mut stack = Vec::new();
         let mut visited: HashSet<*const GcNodeData> = HashSet::new();
         let mut show_names_for = Vec::new();

--- a/src/impl_/gc_node.rs
+++ b/src/impl_/gc_node.rs
@@ -75,7 +75,7 @@ impl GcCtx {
     pub fn make_id(&self) -> u32 {
         self.with_data(|data: &mut GcCtxData| {
             let id = data.next_id;
-            data.next_id = data.next_id + 1;
+            data.next_id += 1;
             id
         })
     }

--- a/src/impl_/lambda.rs
+++ b/src/impl_/lambda.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::many_single_char_names)]
+
 use crate::impl_::dep::Dep;
 
 pub struct Lambda<FN> {

--- a/src/impl_/lambda.rs
+++ b/src/impl_/lambda.rs
@@ -31,32 +31,32 @@ pub fn lambda6_deps<A,B,C,D,E,F,G,FN:IsLambda6<A,B,C,D,E,F,G>>(f: &FN) -> Vec<De
 
 pub trait IsLambda1<A,B> {
     fn call(&mut self, a: &A) -> B;
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>>;
+    fn deps_op(&self) -> Option<&Vec<Dep>>;
 }
 
 pub trait IsLambda2<A,B,C> {
     fn call(&mut self, a: &A, b: &B) -> C;
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>>;
+    fn deps_op(&self) -> Option<&Vec<Dep>>;
 }
 
 pub trait IsLambda3<A,B,C,D> {
     fn call(&mut self, a: &A, b: &B, c: &C) -> D;
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>>;
+    fn deps_op(&self) -> Option<&Vec<Dep>>;
 }
 
 pub trait IsLambda4<A,B,C,D,E> {
     fn call(&mut self, a: &A, b: &B, c: &C, d: &D) -> E;
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>>;
+    fn deps_op(&self) -> Option<&Vec<Dep>>;
 }
 
 pub trait IsLambda5<A,B,C,D,E,F> {
     fn call(&mut self, a: &A, b: &B, c: &C, d: &D, e: &E) -> F;
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>>;
+    fn deps_op(&self) -> Option<&Vec<Dep>>;
 }
 
 pub trait IsLambda6<A,B,C,D,E,F,G> {
     fn call(&mut self, a: &A, b: &B, c: &C, d: &D, e: &E, f: &F) -> G;
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>>;
+    fn deps_op(&self) -> Option<&Vec<Dep>>;
 }
 
 impl<A,B,FN:FnMut(&A)->B> IsLambda1<A,B> for Lambda<FN> {
@@ -65,7 +65,7 @@ impl<A,B,FN:FnMut(&A)->B> IsLambda1<A,B> for Lambda<FN> {
         (self.f)(a)
     }
 
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>> {
+    fn deps_op(&self) -> Option<&Vec<Dep>> {
         Some(&self.deps)
     }
 }
@@ -76,7 +76,7 @@ impl<A,B,FN:FnMut(&A)->B> IsLambda1<A,B> for FN {
         self(a)
     }
 
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>> {
+    fn deps_op(&self) -> Option<&Vec<Dep>> {
         None
     }
 }
@@ -87,7 +87,7 @@ impl<A,B,C,FN:FnMut(&A,&B)->C> IsLambda2<A,B,C> for Lambda<FN> {
         (self.f)(a,b)
     }
 
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>> {
+    fn deps_op(&self) -> Option<&Vec<Dep>> {
         Some(&self.deps)
     }
 }
@@ -98,7 +98,7 @@ impl<A,B,C,FN:FnMut(&A,&B)->C> IsLambda2<A,B,C> for FN {
         self(a,b)
     }
 
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>> {
+    fn deps_op(&self) -> Option<&Vec<Dep>> {
         None
     }
 }
@@ -109,7 +109,7 @@ impl<A,B,C,D,FN:FnMut(&A,&B,&C)->D> IsLambda3<A,B,C,D> for Lambda<FN> {
         (self.f)(a,b,c)
     }
 
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>> {
+    fn deps_op(&self) -> Option<&Vec<Dep>> {
         Some(&self.deps)
     }
 }
@@ -120,7 +120,7 @@ impl<A,B,C,D,FN:FnMut(&A,&B,&C)->D> IsLambda3<A,B,C,D> for FN {
         self(a,b,c)
     }
 
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>> {
+    fn deps_op(&self) -> Option<&Vec<Dep>> {
         None
     }
 }
@@ -131,7 +131,7 @@ impl<A,B,C,D,E,FN:FnMut(&A,&B,&C,&D)->E> IsLambda4<A,B,C,D,E> for Lambda<FN> {
         (self.f)(a,b,c,d)
     }
 
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>> {
+    fn deps_op(&self) -> Option<&Vec<Dep>> {
         Some(&self.deps)
     }
 }
@@ -142,7 +142,7 @@ impl<A,B,C,D,E,FN:FnMut(&A,&B,&C,&D)->E> IsLambda4<A,B,C,D,E> for FN {
         self(a,b,c,d)
     }
 
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>> {
+    fn deps_op(&self) -> Option<&Vec<Dep>> {
         None
     }
 }
@@ -153,7 +153,7 @@ impl<A,B,C,D,E,F,FN:FnMut(&A,&B,&C,&D,&E)->F> IsLambda5<A,B,C,D,E,F> for Lambda<
         (self.f)(a,b,c,d,e)
     }
 
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>> {
+    fn deps_op(&self) -> Option<&Vec<Dep>> {
         Some(&self.deps)
     }
 }
@@ -164,7 +164,7 @@ impl<A,B,C,D,E,F,FN:FnMut(&A,&B,&C,&D,&E)->F> IsLambda5<A,B,C,D,E,F> for FN {
         self(a,b,c,d,e)
     }
 
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>> {
+    fn deps_op(&self) -> Option<&Vec<Dep>> {
         None
     }
 }
@@ -175,7 +175,7 @@ impl<A,B,C,D,E,F,G,FN:FnMut(&A,&B,&C,&D,&E,&F)->G> IsLambda6<A,B,C,D,E,F,G> for 
         (self.f)(a,b,c,d,e,f)
     }
 
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>> {
+    fn deps_op(&self) -> Option<&Vec<Dep>> {
         Some(&self.deps)
     }
 }
@@ -186,7 +186,7 @@ impl<A,B,C,D,E,F,G,FN:FnMut(&A,&B,&C,&D,&E,&F)->G> IsLambda6<A,B,C,D,E,F,G> for 
         self(a,b,c,d,e,f)
     }
 
-    fn deps_op<'r>(&'r self) -> Option<&'r Vec<Dep>> {
+    fn deps_op(&self) -> Option<&Vec<Dep>> {
         None
     }
 }

--- a/src/impl_/lambda.rs
+++ b/src/impl_/lambda.rs
@@ -6,27 +6,27 @@ pub struct Lambda<FN> {
 }
 
 pub fn lambda1_deps<A,B,FN:IsLambda1<A,B>>(f: &FN) -> Vec<Dep> {
-    f.deps_op().map(|deps| deps.clone()).unwrap_or_else(|| Vec::new())
+    f.deps_op().cloned().unwrap_or_else(Vec::new)
 }
 
 pub fn lambda2_deps<A,B,C,FN:IsLambda2<A,B,C>>(f: &FN) -> Vec<Dep> {
-    f.deps_op().map(|deps| deps.clone()).unwrap_or_else(|| Vec::new())
+    f.deps_op().cloned().unwrap_or_else(Vec::new)
 }
 
 pub fn lambda3_deps<A,B,C,D,FN:IsLambda3<A,B,C,D>>(f: &FN) -> Vec<Dep> {
-    f.deps_op().map(|deps| deps.clone()).unwrap_or_else(|| Vec::new())
+    f.deps_op().cloned().unwrap_or_else(Vec::new)
 }
 
 pub fn lambda4_deps<A,B,C,D,E,FN:IsLambda4<A,B,C,D,E>>(f: &FN) -> Vec<Dep> {
-    f.deps_op().map(|deps| deps.clone()).unwrap_or_else(|| Vec::new())
+    f.deps_op().cloned().unwrap_or_else(Vec::new)
 }
 
 pub fn lambda5_deps<A,B,C,D,E,F,FN:IsLambda5<A,B,C,D,E,F>>(f: &FN) -> Vec<Dep> {
-    f.deps_op().map(|deps| deps.clone()).unwrap_or_else(|| Vec::new())
+    f.deps_op().cloned().unwrap_or_else(Vec::new)
 }
 
 pub fn lambda6_deps<A,B,C,D,E,F,G,FN:IsLambda6<A,B,C,D,E,F,G>>(f: &FN) -> Vec<Dep> {
-    f.deps_op().map(|deps| deps.clone()).unwrap_or_else(|| Vec::new())
+    f.deps_op().cloned().unwrap_or_else(Vec::new)
 }
 
 pub trait IsLambda1<A,B> {

--- a/src/impl_/lazy.rs
+++ b/src/impl_/lazy.rs
@@ -38,11 +38,11 @@ impl<A:Send+Clone+'static> Lazy<A> {
         let next_op: Option<LazyData<A>>;
         let result: A;
         match data {
-            &mut LazyData::Thunk(ref mut k) => {
+            LazyData::Thunk(ref mut k) => {
                 result = k();
                 next_op = Some(LazyData::Value(result.clone()));
             },
-            &mut LazyData::Value(ref x) => {
+            LazyData::Value(ref x) => {
                 result = x.clone();
                 next_op = None;
             }

--- a/src/impl_/listener.rs
+++ b/src/impl_/listener.rs
@@ -25,7 +25,7 @@ impl Clone for Listener {
 impl Drop for Listener {
     fn drop(&mut self) {
         self.gc_node.dec_ref();
-    } 
+    }
 }
 
 pub struct ListenerData {
@@ -105,7 +105,7 @@ impl fmt::Debug for Listener {
         write!(f, "(Listener")?;
         match node_op {
             Some(node) => {
-                writeln!(f, "")?;
+                writeln!(f)?;
                 writeln!(f, "{:?})", &node as &(dyn IsNode+Sync+Sync))?;
             }
             None => {

--- a/src/impl_/mod.rs
+++ b/src/impl_/mod.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::borrowed_box)]
+
 pub mod cell;
 pub mod cell_loop;
 pub mod cell_sink;

--- a/src/impl_/node.rs
+++ b/src/impl_/node.rs
@@ -310,7 +310,7 @@ impl Node {
         }
         sodium_ctx.inc_node_ref_count();
         sodium_ctx.inc_node_count();
-        return result;
+        result
     }
 
     pub fn downgrade2(this: &Self) -> WeakNode {
@@ -371,7 +371,7 @@ impl fmt::Debug for dyn IsNode+Sync+Sync {
             pub fn is_visited(&self, node: &Box<dyn IsNode+Send+Sync>) -> bool {
                 let node_data: &NodeData = &node.data();
                 let node_data: *const NodeData = node_data;
-                return self.visited.contains(&node_data);
+                self.visited.contains(&node_data)
             }
             pub fn mark_visitied(&mut self, node: &Box<dyn IsNode+Send+Sync>) {
                 let node_data: &NodeData = &node.data();
@@ -424,6 +424,6 @@ impl fmt::Debug for dyn IsNode+Sync+Sync {
             }
             writeln!(f, "])")?;
         }
-        return fmt::Result::Ok(());
+        fmt::Result::Ok(())
     }
 }

--- a/src/impl_/node.rs
+++ b/src/impl_/node.rs
@@ -353,7 +353,7 @@ impl fmt::Debug for dyn IsNode+Sync+Sync {
                     node_id = existing;
                 } else {
                     node_id = next_id;
-                    next_id = next_id + 1;
+                    next_id += 1;
                     node_id_map.insert(node_data, node_id);
                 }
                 return format!("N{}", node_id);

--- a/src/impl_/node.rs
+++ b/src/impl_/node.rs
@@ -347,7 +347,7 @@ impl fmt::Debug for dyn IsNode+Sync+Sync {
             node_to_id = move |node: &Box<dyn IsNode+Send+Sync>| {
                 let node_data: &NodeData = &node.data();
                 let node_data: *const NodeData = node_data;
-                let existing_op = node_id_map.get(&node_data).map(|x| x.clone());
+                let existing_op = node_id_map.get(&node_data).copied();
                 let node_id;
                 if let Some(existing) = existing_op {
                     node_id = existing;

--- a/src/impl_/node.rs
+++ b/src/impl_/node.rs
@@ -86,7 +86,7 @@ pub trait IsWeakNode: Send + Sync {
     }
 }
 
-pub fn box_clone_vec_is_node(xs: &Vec<Box<dyn IsNode + Send + Sync>>) -> Vec<Box<dyn IsNode + Send + Sync>> {
+pub fn box_clone_vec_is_node(xs: &[Box<dyn IsNode + Send + Sync>]) -> Vec<Box<dyn IsNode + Send + Sync>> {
     let mut result = Vec::with_capacity(xs.len());
     for x in xs {
         result.push(x.box_clone());
@@ -94,7 +94,7 @@ pub fn box_clone_vec_is_node(xs: &Vec<Box<dyn IsNode + Send + Sync>>) -> Vec<Box
     result
 }
 
-pub fn box_clone_vec_is_weak_node(xs: &Vec<Box<dyn IsWeakNode + Send + Sync>>) -> Vec<Box<dyn IsWeakNode + Send + Sync>> {
+pub fn box_clone_vec_is_weak_node(xs: &[Box<dyn IsWeakNode + Send + Sync>]) -> Vec<Box<dyn IsWeakNode + Send + Sync>> {
     let mut result = Vec::with_capacity(xs.len());
     for x in xs {
         result.push(x.box_clone());

--- a/src/impl_/sodium_ctx.rs
+++ b/src/impl_/sodium_ctx.rs
@@ -5,14 +5,16 @@ use crate::impl_::node::{Node, IsNode, IsWeakNode, box_clone_vec_is_node, box_cl
 use std::mem;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::thread;
 
 #[derive(Clone)]
 pub struct SodiumCtx {
     gc_ctx: GcCtx,
     data: Arc<Mutex<SodiumCtxData>>,
-    node_count: Arc<Mutex<usize>>,
-    node_ref_count: Arc<Mutex<usize>>,
+    node_count: Arc<AtomicUsize>,
+    node_ref_count: Arc<AtomicUsize>,
     threaded_mode: Arc<ThreadedMode>
 }
 
@@ -128,8 +130,8 @@ impl SodiumCtx {
                         allow_collect_cycles_counter: 0
                     }
                 )),
-            node_count: Arc::new(Mutex::new(0)),
-            node_ref_count: Arc::new(Mutex::new(0)),
+            node_count: Arc::new(AtomicUsize::new(0)),
+            node_ref_count: Arc::new(AtomicUsize::new(0)),
             threaded_mode: Arc::new(single_threaded_mode())
         }
     }
@@ -189,39 +191,27 @@ impl SodiumCtx {
     }
 
     pub fn node_count(&self) -> usize {
-        self.with_node_count(|node_count: &mut usize| *node_count)
+        self.node_count.load(Ordering::Relaxed)
     }
 
     pub fn inc_node_count(&self) {
-        self.with_node_count(|node_count: &mut usize| *node_count += 1);
+        self.node_count.fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn dec_node_count(&self) {
-        self.with_node_count(|node_count: &mut usize| *node_count -= 1);
-    }
-
-    pub fn with_node_count<R,K:FnOnce(&mut usize)->R>(&self, k: K) -> R {
-        let mut l = self.node_count.lock();
-        let node_count: &mut usize = l.as_mut().unwrap();
-        k(node_count)
+        self.node_count.fetch_sub(1, Ordering::Relaxed);
     }
 
     pub fn node_ref_count(&self) -> usize {
-        self.with_node_ref_count(|node_ref_count: &mut usize| *node_ref_count)
+        self.node_ref_count.load(Ordering::Relaxed)
     }
 
     pub fn inc_node_ref_count(&self) {
-        self.with_node_ref_count(|node_ref_count: &mut usize| *node_ref_count += 1);
+        self.node_ref_count.fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn dec_node_ref_count(&self) {
-        self.with_node_ref_count(|node_ref_count: &mut usize| *node_ref_count -= 1);
-    }
-
-    pub fn with_node_ref_count<R,K:FnOnce(&mut usize)->R>(&self, k: K) -> R {
-        let mut l = self.node_ref_count.lock();
-        let node_ref_count: &mut usize = l.as_mut().unwrap();
-        k(node_ref_count)
+        self.node_ref_count.fetch_sub(1, Ordering::Relaxed);
     }
 
     pub fn end_of_transaction(&self) {

--- a/src/impl_/sodium_ctx.rs
+++ b/src/impl_/sodium_ctx.rs
@@ -32,8 +32,10 @@ pub struct ThreadedMode {
     pub spawner: ThreadSpawner
 }
 
+type SpawnFn = Box<dyn FnOnce()+Send>;
+
 pub struct ThreadSpawner {
-    pub spawn_fn: Box<dyn Fn(Box<dyn FnOnce()+Send>)->ThreadJoiner<()>+Send+Sync>
+    pub spawn_fn: Box<dyn Fn(SpawnFn)->ThreadJoiner<()>+Send+Sync>
 }
 
 pub struct ThreadJoiner<R> {

--- a/src/impl_/sodium_ctx.rs
+++ b/src/impl_/sodium_ctx.rs
@@ -102,6 +102,12 @@ pub fn simple_threaded_mode() -> ThreadedMode {
 // TODO:
 //pub fn thread_pool_threaded_mode(num_threads: usize) -> ThreadedMode
 
+impl Default for SodiumCtx {
+    fn default() -> SodiumCtx {
+        SodiumCtx::new()
+    }
+}
+
 impl SodiumCtx {
     pub fn new() -> SodiumCtx {
         SodiumCtx {

--- a/src/impl_/sodium_ctx.rs
+++ b/src/impl_/sodium_ctx.rs
@@ -142,12 +142,12 @@ impl SodiumCtx {
 
     pub fn transaction<R,K:FnOnce()->R>(&self, k:K) -> R {
         self.with_data(|data: &mut SodiumCtxData| {
-            data.transaction_depth = data.transaction_depth + 1;
+            data.transaction_depth += 1;
         });
         let result = k();
         let is_end_of_transaction =
             self.with_data(|data: &mut SodiumCtxData| {
-                data.transaction_depth = data.transaction_depth - 1;
+                data.transaction_depth -= 1;
                 data.transaction_depth == 0
             });
         if is_end_of_transaction {
@@ -173,7 +173,7 @@ impl SodiumCtx {
             data.pre_post.push(Box::new(k));
         });
     }
-    
+
     pub fn post<K:FnMut()+Send+'static>(&self, k:K) {
         self.with_data(|data: &mut SodiumCtxData| {
             data.post.push(Box::new(k));
@@ -191,11 +191,11 @@ impl SodiumCtx {
     }
 
     pub fn inc_node_count(&self) {
-        self.with_node_count(|node_count: &mut usize| *node_count = *node_count + 1);
+        self.with_node_count(|node_count: &mut usize| *node_count += 1);
     }
 
     pub fn dec_node_count(&self) {
-        self.with_node_count(|node_count: &mut usize| *node_count = *node_count - 1);
+        self.with_node_count(|node_count: &mut usize| *node_count -= 1);
     }
 
     pub fn with_node_count<R,K:FnOnce(&mut usize)->R>(&self, k: K) -> R {
@@ -209,11 +209,11 @@ impl SodiumCtx {
     }
 
     pub fn inc_node_ref_count(&self) {
-        self.with_node_ref_count(|node_ref_count: &mut usize| *node_ref_count = *node_ref_count + 1);
+        self.with_node_ref_count(|node_ref_count: &mut usize| *node_ref_count += 1);
     }
 
     pub fn dec_node_ref_count(&self) {
-        self.with_node_ref_count(|node_ref_count: &mut usize| *node_ref_count = *node_ref_count - 1);
+        self.with_node_ref_count(|node_ref_count: &mut usize| *node_ref_count -= 1);
     }
 
     pub fn with_node_ref_count<R,K:FnOnce(&mut usize)->R>(&self, k: K) -> R {
@@ -224,8 +224,8 @@ impl SodiumCtx {
 
     pub fn end_of_transaction(&self) {
         self.with_data(|data: &mut SodiumCtxData| {
-            data.transaction_depth = data.transaction_depth + 1;
-            data.allow_collect_cycles_counter = data.allow_collect_cycles_counter + 1;
+            data.transaction_depth += 1;
+            data.allow_collect_cycles_counter += 1;
         });
         loop {
             let changed_nodes: Vec<Box<dyn IsNode>> =
@@ -242,7 +242,7 @@ impl SodiumCtx {
             }
         }
         self.with_data(|data: &mut SodiumCtxData| {
-            data.transaction_depth = data.transaction_depth - 1;
+            data.transaction_depth -= 1;
         });
         // pre_post
         let pre_post =
@@ -266,7 +266,7 @@ impl SodiumCtx {
         }
         let allow_collect_cycles =
             self.with_data(|data: &mut SodiumCtxData| {
-                data.allow_collect_cycles_counter = data.allow_collect_cycles_counter - 1;
+                data.allow_collect_cycles_counter -= 1;
                 data.allow_collect_cycles_counter == 0
             });
         if allow_collect_cycles {

--- a/src/impl_/sodium_ctx.rs
+++ b/src/impl_/sodium_ctx.rs
@@ -53,7 +53,7 @@ impl ThreadedMode {
                 *r = Some(r2);
             }));
         }
-        return ThreadJoiner {
+        ThreadJoiner {
             join_fn: Box::new(move || {
                 (thread_joiner.join_fn)();
                 let mut l = r.lock();
@@ -62,7 +62,7 @@ impl ThreadedMode {
                 mem::swap(r, &mut r2);
                 r2.unwrap()
             })
-        };
+        }
     }
 }
 
@@ -148,12 +148,12 @@ impl SodiumCtx {
         let is_end_of_transaction =
             self.with_data(|data: &mut SodiumCtxData| {
                 data.transaction_depth = data.transaction_depth - 1;
-                return data.transaction_depth == 0;
+                data.transaction_depth == 0
             });
         if is_end_of_transaction {
             self.end_of_transaction();
         }
-        return result;
+        result
     }
 
     pub fn add_dependents_to_changed_nodes(&self, node: &dyn IsNode) {
@@ -232,7 +232,7 @@ impl SodiumCtx {
                 self.with_data(|data: &mut SodiumCtxData| {
                     let mut changed_nodes: Vec<Box<dyn IsNode>> = Vec::new();
                     mem::swap(&mut changed_nodes, &mut data.changed_nodes);
-                    return changed_nodes;
+                    changed_nodes
                 });
             if changed_nodes.is_empty() {
                 break;
@@ -249,7 +249,7 @@ impl SodiumCtx {
             self.with_data(|data: &mut SodiumCtxData| {
                 let mut pre_post: Vec<Box<dyn FnMut()+Send>> = Vec::new();
                 mem::swap(&mut pre_post, &mut data.pre_post);
-                return pre_post;
+                pre_post
             });
         for mut k in pre_post {
             k();
@@ -259,7 +259,7 @@ impl SodiumCtx {
             self.with_data(|data: &mut SodiumCtxData| {
                 let mut post: Vec<Box<dyn FnMut()+Send>> = Vec::new();
                 mem::swap(&mut post, &mut data.post);
-                return post;
+                post
             });
         for mut k in post {
             k();

--- a/src/impl_/stream.rs
+++ b/src/impl_/stream.rs
@@ -226,7 +226,7 @@ impl<A:Send+'static> Stream<A> {
 
     pub fn map<B:Send+'static,FN:IsLambda1<A,B>+Send+Sync+'static>(&self, mut f: FN) -> Stream<B> {
         let self_ = self.clone();
-        let sodium_ctx = self.sodium_ctx().clone();
+        let sodium_ctx = self.sodium_ctx();
         Stream::_new(
             &sodium_ctx,
             |s: StreamWeakForwardRef<B>| {
@@ -252,7 +252,7 @@ impl<A:Send+'static> Stream<A> {
 
     pub fn filter<PRED:IsLambda1<A,bool>+Send+Sync+'static>(&self, mut pred: PRED) -> Stream<A> where A: Clone {
         let self_ = self.clone();
-        let sodium_ctx = self.sodium_ctx().clone();
+        let sodium_ctx = self.sodium_ctx();
         Stream::_new(
             &sodium_ctx,
             |s: StreamWeakForwardRef<A>| {
@@ -286,7 +286,7 @@ impl<A:Send+'static> Stream<A> {
         let s2 = s2.clone();
         let s2_node = s2.box_clone();
         let s2_dep = s2.to_dep();
-        let sodium_ctx = self.sodium_ctx().clone();
+        let sodium_ctx = self.sodium_ctx();
         Stream::_new(
             &sodium_ctx,
             |s: StreamWeakForwardRef<A>| {
@@ -386,7 +386,7 @@ impl<A:Send+'static> Stream<A> {
 
     pub fn once(&self) -> Stream<A> where A: Clone {
         let self_ = self.clone();
-        let sodium_ctx = self.sodium_ctx().clone();
+        let sodium_ctx = self.sodium_ctx();
         Stream::_new(
             &sodium_ctx,
             |s: StreamWeakForwardRef<A>| {

--- a/src/impl_/stream.rs
+++ b/src/impl_/stream.rs
@@ -380,7 +380,7 @@ impl<A:Send+'static> Stream<A> {
                 sodium_ctx.post(move || ss.send(a.clone()))
             });
             IsNode::add_keep_alive(&s, &listener.gc_node);
-            return s;
+            s
         })
     }
 

--- a/src/impl_/stream.rs
+++ b/src/impl_/stream.rs
@@ -303,10 +303,8 @@ impl<A:Send+'static> Stream<A> {
                                     } else {
                                         s.unwrap()._send(firing1.clone());
                                     }
-                                } else {
-                                    if let Some(ref firing2) = firing2_op {
-                                        s.unwrap()._send(firing2.clone());
-                                    }
+                                } else if let Some(ref firing2) = firing2_op {
+                                    s.unwrap()._send(firing2.clone());
                                 }
                             })
                         })

--- a/src/impl_/stream.rs
+++ b/src/impl_/stream.rs
@@ -27,6 +27,12 @@ impl<A> Clone for StreamWeakForwardRef<A> {
     }
 }
 
+impl<A: Send+'static> Default for StreamWeakForwardRef<A> {
+    fn default() -> StreamWeakForwardRef<A> {
+        StreamWeakForwardRef::new()
+    }
+}
+
 impl<A:Send+'static> StreamWeakForwardRef<A> {
     pub fn new() -> StreamWeakForwardRef<A> {
         StreamWeakForwardRef {

--- a/src/sodium_ctx.rs
+++ b/src/sodium_ctx.rs
@@ -11,6 +11,12 @@ pub struct SodiumCtx {
     pub impl_: SodiumCtxImpl
 }
 
+impl Default for SodiumCtx {
+    fn default() -> SodiumCtx {
+        SodiumCtx::new()
+    }
+}
+
 impl SodiumCtx {
     pub fn new() -> SodiumCtx {
         SodiumCtx { impl_: SodiumCtxImpl::new() }

--- a/src/tests/cell_loop_test.rs
+++ b/src/tests/cell_loop_test.rs
@@ -7,8 +7,8 @@ use std::sync::Mutex;
 
 #[test]
 fn loop_value_snapshot() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let out = Arc::new(Mutex::new(Vec::new()));
         let l;
@@ -44,8 +44,8 @@ fn loop_value_snapshot() {
 
 #[test]
 fn loop_value_hold() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let out = Arc::new(Mutex::new(Vec::new()));
         let value = sodium_ctx.transaction(
@@ -77,8 +77,8 @@ fn loop_value_hold() {
 
 #[test]
 fn lift_loop() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let out = Arc::new(Mutex::new(Vec::new()));
         let b = sodium_ctx.new_cell_sink("kettle");

--- a/src/tests/cell_test.rs
+++ b/src/tests/cell_test.rs
@@ -8,8 +8,8 @@ use std::sync::Mutex;
 
 #[test]
 fn constant_cell() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let c = sodium_ctx.new_cell(12);
         let out = Arc::new(Mutex::new(Vec::new()));
@@ -77,8 +77,8 @@ fn constant_cell() {
 #[test]
 fn map_c() {
     init();
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let c = sodium_ctx.new_cell_sink(6);
         let out = Arc::new(Mutex::new(Vec::new()));
@@ -103,8 +103,8 @@ fn map_c() {
 
 #[test]
 fn lift_cells_in_switch_c() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     let l;
     {
         let out = Arc::new(Mutex::new(Vec::new()));

--- a/src/tests/stream_test.rs
+++ b/src/tests/stream_test.rs
@@ -12,8 +12,8 @@ use std::sync::Mutex;
 
 #[test]
 fn map() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let s: StreamSink<i32> = sodium_ctx.new_stream_sink();
         let out = Arc::new(Mutex::new(Vec::new()));
@@ -41,8 +41,8 @@ fn map() {
 #[test]
 fn map_to() {
     init();
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     let l;
     {
         let s = sodium_ctx.new_stream_sink();
@@ -71,8 +71,8 @@ fn map_to() {
 
 #[test]
 fn merge_non_simultaneous() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let s1 = sodium_ctx.new_stream_sink();
         let s2 = sodium_ctx.new_stream_sink();
@@ -102,8 +102,8 @@ fn merge_non_simultaneous() {
 
 #[test]
 fn merge_simultaneous() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let s1 = sodium_ctx.new_stream_sink_with_coalescer(|_l, r| *r);
         let s2 = sodium_ctx.new_stream_sink_with_coalescer(|_l, r| *r);
@@ -165,8 +165,8 @@ fn merge_simultaneous() {
 
 #[test]
 fn coalesce() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let s = sodium_ctx.new_stream_sink_with_coalescer(|a, b| *a + *b);
         let out = Arc::new(Mutex::new(Vec::new()));
@@ -201,8 +201,8 @@ fn coalesce() {
 
 #[test]
 fn filter() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let s = sodium_ctx.new_stream_sink();
         let out = Arc::new(Mutex::new(Vec::new()));
@@ -232,8 +232,8 @@ fn filter() {
 
 #[test]
 fn filter_option() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let s: StreamSink<Option<&'static str>> = sodium_ctx.new_stream_sink();
         let out = Arc::new(Mutex::new(Vec::new()));
@@ -264,8 +264,8 @@ fn filter_option() {
 #[test]
 fn merge() {
     init();
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let sa = sodium_ctx.new_stream_sink();
         let sb =
@@ -301,8 +301,8 @@ fn merge() {
 
 #[test]
 fn loop_() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let sa = sodium_ctx.new_stream_sink();
         let sc = sodium_ctx.transaction(
@@ -346,8 +346,8 @@ fn loop_() {
 #[test]
 fn gate() {
     init();
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let s = sodium_ctx.new_stream_sink();
         let pred = sodium_ctx.new_cell_sink(true);
@@ -381,8 +381,8 @@ fn gate() {
 
 #[test]
 fn collect() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     let l;
     {
         let ea = sodium_ctx.new_stream_sink();
@@ -414,8 +414,8 @@ fn collect() {
 #[test]
 fn accum() {
     init();
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     let l;
     {
         let ea = sodium_ctx.new_stream_sink();
@@ -446,8 +446,8 @@ fn accum() {
 
 #[test]
 fn once() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let s = sodium_ctx.new_stream_sink();
         let out = Arc::new(Mutex::new(Vec::new()));
@@ -479,8 +479,8 @@ fn once() {
 #[test]
 fn defer() {
     init();
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let s = sodium_ctx.new_stream_sink();
         let c = s.stream().hold(" ");
@@ -512,8 +512,8 @@ fn defer() {
 
 #[test]
 fn hold() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let s = sodium_ctx.new_stream_sink();
         let c = s.stream().hold(0);
@@ -543,8 +543,8 @@ fn hold() {
 #[test]
 fn hold_is_delayed() {
     init();
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let s = sodium_ctx.new_stream_sink();
         let h = s.stream().hold(0);
@@ -574,8 +574,8 @@ fn hold_is_delayed() {
 
 #[test]
 fn switch_c() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     let l;
     {
         #[derive(Clone)]
@@ -638,8 +638,8 @@ fn switch_c() {
 
 #[test]
 fn switch_s() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     let l;
     {
         #[derive(Clone)]
@@ -706,8 +706,8 @@ fn switch_s() {
 
 #[test]
 fn switch_s_simultaneous() {
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         #[derive(Clone)]
         struct SS2 {
@@ -767,8 +767,8 @@ fn switch_s_simultaneous() {
 #[test]
 fn loop_cell() {
     init();
-    let mut sodium_ctx = SodiumCtx::new();
-    let sodium_ctx = &mut sodium_ctx;
+    let sodium_ctx = SodiumCtx::new();
+    let sodium_ctx = &sodium_ctx;
     {
         let sa = sodium_ctx.new_stream_sink();
         let sum_out = sodium_ctx.transaction(


### PR DESCRIPTION
This is a whole host of minor cleanups mostly reported by Clippy, but a few other things that I just noticed could be simpler.

All of these changes are essentially syntactic differences, and moving the code to use more Rust idioms, remove unneeded code, or make the types used more efficient (fewer pointers) or less unnecessarily restrictive.

I tried to separate the changes into different commits fixing only one kind of error in order to make it easier to review, so it might help to view each commit separately rather than the whole diff at once.

The biggest change to the semantics is changing the `Mutex<usize>` inside of `SodiumCtx` to use `AtomicUsize` instead.  I'm not super familiar with using atomics though so I'm unsure if there is a better ordering that could be applied.

Since this PR fixes or silences all of the outstanding warnings from Clippy, I also made Clippy warnings fail the CI build.

I also changed the way that Clippy is invoked to use the [actions-rs/clippy-check](/actions-rs/clippy-check) action. This might be the most controversial change I made, since it requires using the Github token. The upside is that you get a much more nicely formatted presentation of any clippy warnings that are found, [check them out here](https://github.com/RadicalZephyr/sodium-rust/runs/868704006?check_suite_focus=true).