### PR TITLE
Format code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,13 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: -- -D warnings
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # args: -- -D warnings
+          args: -- -D warnings

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -12,18 +12,22 @@ use crate::stream::Stream;
 use crate::Dep;
 
 pub struct Cell<A> {
-    pub impl_: CellImpl<A>
+    pub impl_: CellImpl<A>,
 }
 
 impl<A> Clone for Cell<A> {
     fn clone(&self) -> Self {
-        Cell { impl_: self.impl_.clone() }
+        Cell {
+            impl_: self.impl_.clone(),
+        }
     }
 }
 
-impl<A:Clone+Send+'static> Cell<A> {
+impl<A: Clone + Send + 'static> Cell<A> {
     pub fn new(sodium_ctx: &SodiumCtx, value: A) -> Cell<A> {
-        Cell { impl_: CellImpl::new(&sodium_ctx.impl_, value) }
+        Cell {
+            impl_: CellImpl::new(&sodium_ctx.impl_, value),
+        }
     }
 
     pub fn sample(&self) -> A {
@@ -40,50 +44,141 @@ impl<A:Clone+Send+'static> Cell<A> {
     }
 
     pub fn updates(&self) -> Stream<A> {
-        Stream { impl_: self.impl_.updates() }
+        Stream {
+            impl_: self.impl_.updates(),
+        }
     }
 
     pub fn value(&self) -> Stream<A> {
-        Stream { impl_: self.impl_.value() }
+        Stream {
+            impl_: self.impl_.value(),
+        }
     }
 
-    pub fn map<B:Clone+Send+'static,FN:IsLambda1<A,B>+Send+Sync+'static>(&self, f: FN) -> Cell<B> {
-        Cell { impl_: self.impl_.map(f) }
+    pub fn map<B: Clone + Send + 'static, FN: IsLambda1<A, B> + Send + Sync + 'static>(
+        &self,
+        f: FN,
+    ) -> Cell<B> {
+        Cell {
+            impl_: self.impl_.map(f),
+        }
     }
 
-    pub fn lift2<B:Clone+Send+'static,C:Clone+Send+'static,FN:IsLambda2<A,B,C>+Send+'static>(&self, cb: &Cell<B>, f: FN) -> Cell<C> {
-        Cell { impl_: self.impl_.lift2(&cb.impl_, f) }
+    pub fn lift2<
+        B: Clone + Send + 'static,
+        C: Clone + Send + 'static,
+        FN: IsLambda2<A, B, C> + Send + 'static,
+    >(
+        &self,
+        cb: &Cell<B>,
+        f: FN,
+    ) -> Cell<C> {
+        Cell {
+            impl_: self.impl_.lift2(&cb.impl_, f),
+        }
     }
 
-    pub fn lift3<B:Clone+Send+'static,C:Clone+Send+'static,D:Clone+Send+'static,FN:IsLambda3<A,B,C,D>+Send+'static>(&self, cb: &Cell<B>, cc: &Cell<C>, f: FN) -> Cell<D> {
-        Cell { impl_: self.impl_.lift3(&cb.impl_, &cc.impl_, f) }
+    pub fn lift3<
+        B: Clone + Send + 'static,
+        C: Clone + Send + 'static,
+        D: Clone + Send + 'static,
+        FN: IsLambda3<A, B, C, D> + Send + 'static,
+    >(
+        &self,
+        cb: &Cell<B>,
+        cc: &Cell<C>,
+        f: FN,
+    ) -> Cell<D> {
+        Cell {
+            impl_: self.impl_.lift3(&cb.impl_, &cc.impl_, f),
+        }
     }
 
-    pub fn lift4<B:Clone+Send+'static,C:Clone+Send+'static,D:Clone+Send+'static,E:Clone+Send+'static,FN:IsLambda4<A,B,C,D,E>+Send+'static>(&self, cb: &Cell<B>, cc: &Cell<C>, cd: &Cell<D>, f: FN) -> Cell<E> {
-        Cell { impl_: self.impl_.lift4(&cb.impl_, &cc.impl_, &cd.impl_, f) }
+    pub fn lift4<
+        B: Clone + Send + 'static,
+        C: Clone + Send + 'static,
+        D: Clone + Send + 'static,
+        E: Clone + Send + 'static,
+        FN: IsLambda4<A, B, C, D, E> + Send + 'static,
+    >(
+        &self,
+        cb: &Cell<B>,
+        cc: &Cell<C>,
+        cd: &Cell<D>,
+        f: FN,
+    ) -> Cell<E> {
+        Cell {
+            impl_: self.impl_.lift4(&cb.impl_, &cc.impl_, &cd.impl_, f),
+        }
     }
 
-    pub fn lift5<B:Clone+Send+'static,C:Clone+Send+'static,D:Clone+Send+'static,E:Clone+Send+'static,F:Clone+Send+'static,FN:IsLambda5<A,B,C,D,E,F>+Send+'static>(&self, cb: &Cell<B>, cc: &Cell<C>, cd: &Cell<D>, ce: &Cell<E>, f: FN) -> Cell<F> {
-        Cell { impl_: self.impl_.lift5(&cb.impl_, &cc.impl_, &cd.impl_, &ce.impl_, f) }
+    pub fn lift5<
+        B: Clone + Send + 'static,
+        C: Clone + Send + 'static,
+        D: Clone + Send + 'static,
+        E: Clone + Send + 'static,
+        F: Clone + Send + 'static,
+        FN: IsLambda5<A, B, C, D, E, F> + Send + 'static,
+    >(
+        &self,
+        cb: &Cell<B>,
+        cc: &Cell<C>,
+        cd: &Cell<D>,
+        ce: &Cell<E>,
+        f: FN,
+    ) -> Cell<F> {
+        Cell {
+            impl_: self
+                .impl_
+                .lift5(&cb.impl_, &cc.impl_, &cd.impl_, &ce.impl_, f),
+        }
     }
 
-    pub fn lift6<B:Clone+Send+'static,C:Clone+Send+'static,D:Clone+Send+'static,E:Clone+Send+'static,F:Clone+Send+'static,G:Clone+Send+'static,FN:IsLambda6<A,B,C,D,E,F,G>+Send+'static>(&self, cb: &Cell<B>, cc: &Cell<C>, cd: &Cell<D>, ce: &Cell<E>, cf: &Cell<F>, f: FN) -> Cell<G> {
-        Cell { impl_: self.impl_.lift6(&cb.impl_, &cc.impl_, &cd.impl_, &ce.impl_, &cf.impl_, f) }
+    pub fn lift6<
+        B: Clone + Send + 'static,
+        C: Clone + Send + 'static,
+        D: Clone + Send + 'static,
+        E: Clone + Send + 'static,
+        F: Clone + Send + 'static,
+        G: Clone + Send + 'static,
+        FN: IsLambda6<A, B, C, D, E, F, G> + Send + 'static,
+    >(
+        &self,
+        cb: &Cell<B>,
+        cc: &Cell<C>,
+        cd: &Cell<D>,
+        ce: &Cell<E>,
+        cf: &Cell<F>,
+        f: FN,
+    ) -> Cell<G> {
+        Cell {
+            impl_: self
+                .impl_
+                .lift6(&cb.impl_, &cc.impl_, &cd.impl_, &ce.impl_, &cf.impl_, f),
+        }
     }
 
     pub fn switch_s(csa: &Cell<Stream<A>>) -> Stream<A> {
-        Stream { impl_: CellImpl::switch_s(&csa.map(|sa: &Stream<A>| sa.impl_.clone()).impl_) }
+        Stream {
+            impl_: CellImpl::switch_s(&csa.map(|sa: &Stream<A>| sa.impl_.clone()).impl_),
+        }
     }
 
     pub fn switch_c(cca: &Cell<Cell<A>>) -> Cell<A> {
-        Cell { impl_: CellImpl::switch_c(&cca.map(|ca: &Cell<A>| ca.impl_.clone()).impl_) }
+        Cell {
+            impl_: CellImpl::switch_c(&cca.map(|ca: &Cell<A>| ca.impl_.clone()).impl_),
+        }
     }
 
-    pub fn listen_weak<K: FnMut(&A)+Send+Sync+'static>(&self, k: K) -> Listener {
-        Listener { impl_: self.impl_.listen_weak(k) }
+    pub fn listen_weak<K: FnMut(&A) + Send + Sync + 'static>(&self, k: K) -> Listener {
+        Listener {
+            impl_: self.impl_.listen_weak(k),
+        }
     }
 
-    pub fn listen<K:IsLambda1<A,()>+Send+Sync+'static>(&self, k: K) -> Listener {
-        Listener { impl_: self.impl_.listen(k) }
+    pub fn listen<K: IsLambda1<A, ()> + Send + Sync + 'static>(&self, k: K) -> Listener {
+        Listener {
+            impl_: self.impl_.listen(k),
+        }
     }
 }

--- a/src/cell_loop.rs
+++ b/src/cell_loop.rs
@@ -1,29 +1,30 @@
+use crate::impl_::cell_loop::CellLoop as CellLoopImpl;
 use crate::Cell;
 use crate::SodiumCtx;
-use crate::impl_::cell_loop::CellLoop as CellLoopImpl;
 
 pub struct CellLoop<A> {
-    impl_: CellLoopImpl<A>
+    impl_: CellLoopImpl<A>,
 }
 
 impl<A> Clone for CellLoop<A> {
     fn clone(&self) -> Self {
         CellLoop {
-            impl_: self.impl_.clone()
+            impl_: self.impl_.clone(),
         }
     }
 }
 
-impl<A:Send+Clone+'static> CellLoop<A> {
-
+impl<A: Send + Clone + 'static> CellLoop<A> {
     pub fn new(sodium_ctx: &SodiumCtx) -> CellLoop<A> {
         CellLoop {
-            impl_: CellLoopImpl::new(&sodium_ctx.impl_)
+            impl_: CellLoopImpl::new(&sodium_ctx.impl_),
         }
     }
 
     pub fn cell(&self) -> Cell<A> {
-        Cell { impl_: self.impl_.cell() }
+        Cell {
+            impl_: self.impl_.cell(),
+        }
     }
 
     pub fn loop_(&self, ca: &Cell<A>) {

--- a/src/cell_sink.rs
+++ b/src/cell_sink.rs
@@ -1,26 +1,30 @@
+use crate::cell::Cell;
 use crate::impl_::cell_sink::CellSink as CellSinkImpl;
 use crate::sodium_ctx::SodiumCtx;
-use crate::cell::Cell;
 
 pub struct CellSink<A> {
-    pub impl_: CellSinkImpl<A>
+    pub impl_: CellSinkImpl<A>,
 }
 
 impl<A> Clone for CellSink<A> {
     fn clone(&self) -> Self {
         CellSink {
-            impl_: self.impl_.clone()
+            impl_: self.impl_.clone(),
         }
     }
 }
 
-impl<A:Clone+Send+'static> CellSink<A> {
+impl<A: Clone + Send + 'static> CellSink<A> {
     pub fn new(sodium_ctx: &SodiumCtx, a: A) -> CellSink<A> {
-        CellSink { impl_: CellSinkImpl::new(&sodium_ctx.impl_, a) }
+        CellSink {
+            impl_: CellSinkImpl::new(&sodium_ctx.impl_, a),
+        }
     }
 
     pub fn cell(&self) -> Cell<A> {
-        Cell { impl_: self.impl_.cell() }
+        Cell {
+            impl_: self.impl_.cell(),
+        }
     }
 
     pub fn send(&self, a: A) {

--- a/src/impl_/cell.rs
+++ b/src/impl_/cell.rs
@@ -1,19 +1,21 @@
 use crate::impl_::dep::Dep;
-use crate::impl_::lazy::Lazy;
-use crate::impl_::listener::Listener;
-use crate::impl_::node::{Node, WeakNode, IsNode};
-use crate::impl_::sodium_ctx::SodiumCtx;
-use crate::impl_::sodium_ctx::SodiumCtxData;
-use crate::impl_::stream::Stream;
-use crate::impl_::stream::WeakStream;
-use crate::impl_::stream::StreamWeakForwardRef;
 use crate::impl_::lambda::IsLambda1;
 use crate::impl_::lambda::IsLambda2;
 use crate::impl_::lambda::IsLambda3;
 use crate::impl_::lambda::IsLambda4;
 use crate::impl_::lambda::IsLambda5;
 use crate::impl_::lambda::IsLambda6;
-use crate::impl_::lambda::{lambda1, lambda2, lambda3, lambda2_deps, lambda3_deps, lambda4_deps, lambda5_deps, lambda6_deps};
+use crate::impl_::lambda::{
+    lambda1, lambda2, lambda2_deps, lambda3, lambda3_deps, lambda4_deps, lambda5_deps, lambda6_deps,
+};
+use crate::impl_::lazy::Lazy;
+use crate::impl_::listener::Listener;
+use crate::impl_::node::{IsNode, Node, WeakNode};
+use crate::impl_::sodium_ctx::SodiumCtx;
+use crate::impl_::sodium_ctx::SodiumCtxData;
+use crate::impl_::stream::Stream;
+use crate::impl_::stream::StreamWeakForwardRef;
+use crate::impl_::stream::WeakStream;
 
 use std::mem;
 use std::sync::Arc;
@@ -22,21 +24,21 @@ use std::sync::RwLock;
 use std::sync::Weak;
 
 pub struct CellWeakForwardRef<A> {
-    data: Arc<RwLock<Option<WeakCell<A>>>>
+    data: Arc<RwLock<Option<WeakCell<A>>>>,
 }
 
 impl<A> Clone for CellWeakForwardRef<A> {
     fn clone(&self) -> Self {
         CellWeakForwardRef {
-            data: self.data.clone()
+            data: self.data.clone(),
         }
     }
 }
 
-impl<A:Send+'static> CellWeakForwardRef<A> {
+impl<A: Send + 'static> CellWeakForwardRef<A> {
     pub fn new() -> CellWeakForwardRef<A> {
         CellWeakForwardRef {
-            data: Arc::new(RwLock::new(None))
+            data: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -53,19 +55,19 @@ impl<A:Send+'static> CellWeakForwardRef<A> {
 
 pub struct Cell<A> {
     pub data: Arc<Mutex<CellData<A>>>,
-    pub node: Node
+    pub node: Node,
 }
 
 pub struct WeakCell<A> {
     pub data: Weak<Mutex<CellData<A>>>,
-    pub node: WeakNode
+    pub node: WeakNode,
 }
 
 impl<A> Clone for Cell<A> {
     fn clone(&self) -> Self {
         Cell {
             data: self.data.clone(),
-            node: self.node.clone()
+            node: self.node.clone(),
         }
     }
 }
@@ -74,7 +76,7 @@ impl<A> Clone for WeakCell<A> {
     fn clone(&self) -> Self {
         WeakCell {
             data: self.data.clone(),
-            node: self.node.clone()
+            node: self.node.clone(),
         }
     }
 }
@@ -82,11 +84,11 @@ impl<A> Clone for WeakCell<A> {
 pub struct CellData<A> {
     stream: Stream<A>,
     value: Lazy<A>,
-    next_value_op: Option<A>
+    next_value_op: Option<A>,
 }
 
 impl<A> Cell<A> {
-    pub fn with_data<R,K:FnOnce(&mut CellData<A>)->R>(&self, k: K) -> R {
+    pub fn with_data<R, K: FnOnce(&mut CellData<A>) -> R>(&self, k: K) -> R {
         let mut l = self.data.lock();
         let data: &mut CellData<A> = l.as_mut().unwrap();
         k(data)
@@ -105,8 +107,11 @@ impl<A> Cell<A> {
     }
 }
 
-impl<A:Send+'static> Cell<A> {
-    pub fn new(sodium_ctx: &SodiumCtx, value: A) -> Cell<A> where A: Clone {
+impl<A: Send + 'static> Cell<A> {
+    pub fn new(sodium_ctx: &SodiumCtx, value: A) -> Cell<A>
+    where
+        A: Clone,
+    {
         let cell_data = Arc::new(Mutex::new(CellData {
             stream: Stream::new(sodium_ctx),
             value: Lazy::of_value(value),
@@ -114,25 +119,22 @@ impl<A:Send+'static> Cell<A> {
         }));
         Cell {
             data: cell_data,
-            node: Node::new(
-                sodium_ctx,
-                "Cell::new",
-                || {},
-                vec![]
-            )
+            node: Node::new(sodium_ctx, "Cell::new", || {}, vec![]),
         }
     }
 
-    pub fn _new(sodium_ctx: &SodiumCtx, stream: Stream<A>, value: Lazy<A>) -> Cell<A> where A: Clone {
-        let init_value =
-            stream.with_firing_op(|firing_op: &mut Option<A>| {
-                if let Some(ref firing) = firing_op {
-                    let firing = firing.clone();
-                    Lazy::new(move || firing.clone())
-                } else {
-                    value
-                }
-            });
+    pub fn _new(sodium_ctx: &SodiumCtx, stream: Stream<A>, value: Lazy<A>) -> Cell<A>
+    where
+        A: Clone,
+    {
+        let init_value = stream.with_firing_op(|firing_op: &mut Option<A>| {
+            if let Some(ref firing) = firing_op {
+                let firing = firing.clone();
+                Lazy::new(move || firing.clone())
+            } else {
+                value
+            }
+        });
         let cell_data = Arc::new(Mutex::new(CellData {
             stream: stream.clone(),
             value: init_value,
@@ -153,12 +155,11 @@ impl<A:Send+'static> Cell<A> {
                     let c = c.unwrap();
                     let firing_op = stream.with_firing_op(|firing_op| firing_op.clone());
                     if let Some(firing) = firing_op {
-                        let is_first =
-                            c.with_data(|data: &mut CellData<A>| {
-                                let is_first = data.next_value_op.is_none();
-                                data.next_value_op = Some(firing);
-                                is_first
-                            });
+                        let is_first = c.with_data(|data: &mut CellData<A>| {
+                            let is_first = data.next_value_op.is_none();
+                            data.next_value_op = Some(firing);
+                            is_first
+                        });
                         if is_first {
                             sodium_ctx.post(move || {
                                 c.with_data(|data: &mut CellData<A>| {
@@ -172,20 +173,23 @@ impl<A:Send+'static> Cell<A> {
                         }
                     }
                 },
-                vec![stream_node]
+                vec![stream_node],
             );
             // Hack: Add stream gc node twice, because one is kepted in the cell_data for Cell::update() to return.
             IsNode::add_update_dependencies(&node, vec![stream_dep.clone(), stream_dep]);
         }
         let c = Cell {
             data: cell_data,
-            node
+            node,
         };
         c_forward_ref.assign(&c);
         c
     }
 
-    pub fn sample(&self) -> A where A: Clone {
+    pub fn sample(&self) -> A
+    where
+        A: Clone,
+    {
         self.with_data(|data: &mut CellData<A>| data.value.run())
     }
 
@@ -197,7 +201,10 @@ impl<A:Send+'static> Cell<A> {
         self.with_data(|data: &mut CellData<A>| data.stream.clone())
     }
 
-    pub fn value(&self) -> Stream<A> where A: Clone {
+    pub fn value(&self) -> Stream<A>
+    where
+        A: Clone,
+    {
         let sodium_ctx = self.sodium_ctx();
         sodium_ctx.transaction(|| {
             let s1 = self.updates();
@@ -214,7 +221,9 @@ impl<A:Send+'static> Cell<A> {
                             let mut changed = node.data.changed.write().unwrap();
                             *changed = true;
                         }
-                        sodium_ctx2.with_data(|data: &mut SodiumCtxData| data.changed_nodes.push(node.box_clone()));
+                        sodium_ctx2.with_data(|data: &mut SodiumCtxData| {
+                            data.changed_nodes.push(node.box_clone())
+                        });
                         spark._send(a.clone());
                     });
                 });
@@ -223,12 +232,30 @@ impl<A:Send+'static> Cell<A> {
         })
     }
 
-    pub fn map<B:Send+'static,FN:IsLambda1<A,B>+Send+Sync+'static>(&self, mut f: FN) -> Cell<B> where A: Clone, B: Clone {
+    pub fn map<B: Send + 'static, FN: IsLambda1<A, B> + Send + Sync + 'static>(
+        &self,
+        mut f: FN,
+    ) -> Cell<B>
+    where
+        A: Clone,
+        B: Clone,
+    {
         let init = f.call(&self.sample());
         self.updates().map(f).hold(init)
     }
 
-    pub fn lift2<B:Send+Clone+'static,C:Send+Clone+'static,FN:IsLambda2<A,B,C>+Send+'static>(&self, cb: &Cell<B>, f: FN) -> Cell<C> where A: Clone {
+    pub fn lift2<
+        B: Send + Clone + 'static,
+        C: Send + Clone + 'static,
+        FN: IsLambda2<A, B, C> + Send + 'static,
+    >(
+        &self,
+        cb: &Cell<B>,
+        f: FN,
+    ) -> Cell<C>
+    where
+        A: Clone,
+    {
         let sodium_ctx = self.sodium_ctx();
         let lhs = self.sample_lazy();
         let rhs = cb.sample_lazy();
@@ -245,14 +272,14 @@ impl<A:Send+'static> Cell<A> {
                 f.call(&lhs.run(), &rhs.run())
             });
         }
-        let state: Arc<Mutex<(Lazy<A>,Lazy<B>)>> = Arc::new(Mutex::new((lhs, rhs)));
+        let state: Arc<Mutex<(Lazy<A>, Lazy<B>)>> = Arc::new(Mutex::new((lhs, rhs)));
         let s1: Stream<()>;
         let s2: Stream<()>;
         {
             let state = state.clone();
             s1 = self.updates().map(move |a: &A| {
                 let mut l = state.lock();
-                let state2: &mut (Lazy<A>,Lazy<B>) = l.as_mut().unwrap();
+                let state2: &mut (Lazy<A>, Lazy<B>) = l.as_mut().unwrap();
                 state2.0 = Lazy::of_value(a.clone());
             });
         }
@@ -260,204 +287,246 @@ impl<A:Send+'static> Cell<A> {
             let state = state.clone();
             s2 = cb.updates().map(move |b: &B| {
                 let mut l = state.lock();
-                let state2: &mut (Lazy<A>,Lazy<B>) = l.as_mut().unwrap();
+                let state2: &mut (Lazy<A>, Lazy<B>) = l.as_mut().unwrap();
                 state2.1 = Lazy::of_value(b.clone());
             });
         }
-        let s = s1.or_else(&s2).map(lambda1(move |_: &()| {
-            let l = state.lock();
-            let state2: &(Lazy<A>,Lazy<B>) = l.as_ref().unwrap();
-            let mut l = f.lock();
-            let f = l.as_mut().unwrap();
-            f.call(&state2.0.run(), &state2.1.run())
-        }, f_deps));
-        Cell::_new(
-            &sodium_ctx,
-            s,
-            init
-        )
+        let s = s1.or_else(&s2).map(lambda1(
+            move |_: &()| {
+                let l = state.lock();
+                let state2: &(Lazy<A>, Lazy<B>) = l.as_ref().unwrap();
+                let mut l = f.lock();
+                let f = l.as_mut().unwrap();
+                f.call(&state2.0.run(), &state2.1.run())
+            },
+            f_deps,
+        ));
+        Cell::_new(&sodium_ctx, s, init)
     }
 
     pub fn lift3<
-        B:Send+Clone+'static,
-        C:Send+Clone+'static,
-        D:Send+Clone+'static,
-        FN:IsLambda3<A,B,C,D>+Send+'static
-    >(&self, cb: &Cell<B>, cc: &Cell<C>, mut f: FN) -> Cell<D> where A: Clone {
+        B: Send + Clone + 'static,
+        C: Send + Clone + 'static,
+        D: Send + Clone + 'static,
+        FN: IsLambda3<A, B, C, D> + Send + 'static,
+    >(
+        &self,
+        cb: &Cell<B>,
+        cc: &Cell<C>,
+        mut f: FN,
+    ) -> Cell<D>
+    where
+        A: Clone,
+    {
         let f_deps = lambda3_deps(&f);
-        self
-            .lift2(
-                cb,
-                |a: &A, b: &B| (a.clone(), b.clone())
-            )
-            .lift2(
-                cc,
-                lambda2(move |(ref a, ref b): &(A,B), c: &C| f.call(a, b, c), f_deps)
-            )
-    }
-
-    pub fn lift4<
-        B:Send+Clone+'static,
-        C:Send+Clone+'static,
-        D:Send+Clone+'static,
-        E:Send+Clone+'static,
-        FN:IsLambda4<A,B,C,D,E>+Send+'static
-    >(&self, cb: &Cell<B>, cc: &Cell<C>, cd: &Cell<D>, mut f: FN) -> Cell<E> where A: Clone {
-        let f_deps = lambda4_deps(&f);
-        self
-            .lift3(
-                cb,
-                cc,
-                |a: &A, b: &B, c: &C| (a.clone(), b.clone(), c.clone())
-            )
-            .lift2(
-                cd,
-                lambda2(move |(ref a, ref b, ref c): &(A,B,C), d: &D| f.call(a, b, c, d), f_deps)
-            )
-    }
-
-    pub fn lift5<
-        B:Send+Clone+'static,
-        C:Send+Clone+'static,
-        D:Send+Clone+'static,
-        E:Send+Clone+'static,
-        F:Send+Clone+'static,
-        FN:IsLambda5<A,B,C,D,E,F>+Send+'static
-    >(&self, cb: &Cell<B>, cc: &Cell<C>, cd: &Cell<D>, ce: &Cell<E>, mut f: FN) -> Cell<F> where A: Clone {
-        let f_deps = lambda5_deps(&f);
-        self
-            .lift3(
-                cb,
-                cc,
-                |a: &A, b: &B, c: &C| (a.clone(), b.clone(), c.clone())
-            )
-            .lift3(
-                cd,
-                ce,
-                lambda3(move |(ref a, ref b, ref c): &(A,B,C), d: &D, e: &E| f.call(a, b, c, d, e), f_deps)
-            )
-    }
-
-    pub fn lift6<
-        B:Send+Clone+'static,
-        C:Send+Clone+'static,
-        D:Send+Clone+'static,
-        E:Send+Clone+'static,
-        F:Send+Clone+'static,
-        G:Send+Clone+'static,
-        FN:IsLambda6<A,B,C,D,E,F,G>+Send+'static
-    >(&self, cb: &Cell<B>, cc: &Cell<C>, cd: &Cell<D>, ce: &Cell<E>, cf: &Cell<F>, mut f: FN) -> Cell<G> where A: Clone {
-        let f_deps = lambda6_deps(&f);
-        self
-            .lift4(
-                cb,
-                cc,
-                cd,
-                |a: &A, b: &B, c: &C, d: &D| (a.clone(), b.clone(), c.clone(), d.clone())
-            )
-            .lift3(
-                ce,
-                cf,
-                lambda3(move |(ref a, ref b, ref c, ref d): &(A,B,C,D), e: &E, f2: &F| f.call(a, b, c, d, e, f2), f_deps)
-            )
-    }
-
-    pub fn switch_s(csa: &Cell<Stream<A>>) -> Stream<A> where A: Clone {
-        let csa = csa.clone();
-        let sodium_ctx = csa.sodium_ctx();
-        Stream::_new(
-            &sodium_ctx,
-            |sa: StreamWeakForwardRef<A>| {
-                let inner_s: Arc<Mutex<WeakStream<A>>> = Arc::new(Mutex::new(Stream::downgrade(&csa.sample())));
-                let sa = sa;
-                let node1: Node;
-                {
-                    let inner_s = inner_s.clone();
-                    node1 = Node::new(
-                        &sodium_ctx,
-                        "switch_s inner node",
-                        move || {
-                            let l = inner_s.lock();
-                            let inner_s: &WeakStream<A> = l.as_ref().unwrap();
-                            let inner_s = inner_s.upgrade().unwrap();
-                            inner_s.with_firing_op(|firing_op: &mut Option<A>| {
-                                if let Some(ref firing) = firing_op {
-                                    let sa = sa.unwrap();
-                                    sa._send(firing.clone());
-                                }
-                            });
-                        },
-                        vec![csa.sample().box_clone()]
-                    );
-                }
-                let node2: Node;
-                let csa_updates = csa.updates();
-                let csa_updates_node = csa_updates.box_clone();
-                let csa_updates_dep = csa_updates.to_dep();
-                {
-                    let node1: Node = node1.clone();
-                    let sodium_ctx = sodium_ctx.clone();
-                    let sodium_ctx2 = sodium_ctx.clone();
-                    node2 = Node::new(
-                        &sodium_ctx2,
-                        "switch_s outer node",
-                        move || {
-                            csa_updates.with_firing_op(|firing_op: &mut Option<Stream<A>>| {
-                                if let Some(ref firing) = firing_op {
-                                    let firing = firing.clone();
-                                    let node1 = node1.clone();
-                                    let inner_s = inner_s.clone();
-                                    sodium_ctx.pre_post(move || {
-                                        let mut l = inner_s.lock();
-                                        let inner_s: &mut WeakStream<A> = l.as_mut().unwrap();
-                                        IsNode::remove_dependency(&node1, &inner_s.upgrade().unwrap());
-                                        IsNode::add_dependency(&node1, firing.clone());
-                                        *inner_s = Stream::downgrade(&firing);
-                                    });
-                                }
-                            });
-                        },
-                        vec![csa_updates_node.box_clone()]
-                    );
-                }
-                IsNode::add_update_dependencies(&node2, vec![csa_updates_dep, Dep::new(node1.gc_node().clone())]);
-                IsNode::add_dependency(&node1, node2);
-                node1
-            }
+        self.lift2(cb, |a: &A, b: &B| (a.clone(), b.clone())).lift2(
+            cc,
+            lambda2(
+                move |(ref a, ref b): &(A, B), c: &C| f.call(a, b, c),
+                f_deps,
+            ),
         )
     }
 
-    pub fn switch_c(cca: &Cell<Cell<A>>) -> Cell<A> where A: Clone {
+    pub fn lift4<
+        B: Send + Clone + 'static,
+        C: Send + Clone + 'static,
+        D: Send + Clone + 'static,
+        E: Send + Clone + 'static,
+        FN: IsLambda4<A, B, C, D, E> + Send + 'static,
+    >(
+        &self,
+        cb: &Cell<B>,
+        cc: &Cell<C>,
+        cd: &Cell<D>,
+        mut f: FN,
+    ) -> Cell<E>
+    where
+        A: Clone,
+    {
+        let f_deps = lambda4_deps(&f);
+        self.lift3(cb, cc, |a: &A, b: &B, c: &C| {
+            (a.clone(), b.clone(), c.clone())
+        })
+        .lift2(
+            cd,
+            lambda2(
+                move |(ref a, ref b, ref c): &(A, B, C), d: &D| f.call(a, b, c, d),
+                f_deps,
+            ),
+        )
+    }
+
+    pub fn lift5<
+        B: Send + Clone + 'static,
+        C: Send + Clone + 'static,
+        D: Send + Clone + 'static,
+        E: Send + Clone + 'static,
+        F: Send + Clone + 'static,
+        FN: IsLambda5<A, B, C, D, E, F> + Send + 'static,
+    >(
+        &self,
+        cb: &Cell<B>,
+        cc: &Cell<C>,
+        cd: &Cell<D>,
+        ce: &Cell<E>,
+        mut f: FN,
+    ) -> Cell<F>
+    where
+        A: Clone,
+    {
+        let f_deps = lambda5_deps(&f);
+        self.lift3(cb, cc, |a: &A, b: &B, c: &C| {
+            (a.clone(), b.clone(), c.clone())
+        })
+        .lift3(
+            cd,
+            ce,
+            lambda3(
+                move |(ref a, ref b, ref c): &(A, B, C), d: &D, e: &E| f.call(a, b, c, d, e),
+                f_deps,
+            ),
+        )
+    }
+
+    pub fn lift6<
+        B: Send + Clone + 'static,
+        C: Send + Clone + 'static,
+        D: Send + Clone + 'static,
+        E: Send + Clone + 'static,
+        F: Send + Clone + 'static,
+        G: Send + Clone + 'static,
+        FN: IsLambda6<A, B, C, D, E, F, G> + Send + 'static,
+    >(
+        &self,
+        cb: &Cell<B>,
+        cc: &Cell<C>,
+        cd: &Cell<D>,
+        ce: &Cell<E>,
+        cf: &Cell<F>,
+        mut f: FN,
+    ) -> Cell<G>
+    where
+        A: Clone,
+    {
+        let f_deps = lambda6_deps(&f);
+        self.lift4(cb, cc, cd, |a: &A, b: &B, c: &C, d: &D| {
+            (a.clone(), b.clone(), c.clone(), d.clone())
+        })
+        .lift3(
+            ce,
+            cf,
+            lambda3(
+                move |(ref a, ref b, ref c, ref d): &(A, B, C, D), e: &E, f2: &F| {
+                    f.call(a, b, c, d, e, f2)
+                },
+                f_deps,
+            ),
+        )
+    }
+
+    pub fn switch_s(csa: &Cell<Stream<A>>) -> Stream<A>
+    where
+        A: Clone,
+    {
+        let csa = csa.clone();
+        let sodium_ctx = csa.sodium_ctx();
+        Stream::_new(&sodium_ctx, |sa: StreamWeakForwardRef<A>| {
+            let inner_s: Arc<Mutex<WeakStream<A>>> =
+                Arc::new(Mutex::new(Stream::downgrade(&csa.sample())));
+            let sa = sa;
+            let node1: Node;
+            {
+                let inner_s = inner_s.clone();
+                node1 = Node::new(
+                    &sodium_ctx,
+                    "switch_s inner node",
+                    move || {
+                        let l = inner_s.lock();
+                        let inner_s: &WeakStream<A> = l.as_ref().unwrap();
+                        let inner_s = inner_s.upgrade().unwrap();
+                        inner_s.with_firing_op(|firing_op: &mut Option<A>| {
+                            if let Some(ref firing) = firing_op {
+                                let sa = sa.unwrap();
+                                sa._send(firing.clone());
+                            }
+                        });
+                    },
+                    vec![csa.sample().box_clone()],
+                );
+            }
+            let node2: Node;
+            let csa_updates = csa.updates();
+            let csa_updates_node = csa_updates.box_clone();
+            let csa_updates_dep = csa_updates.to_dep();
+            {
+                let node1: Node = node1.clone();
+                let sodium_ctx = sodium_ctx.clone();
+                let sodium_ctx2 = sodium_ctx.clone();
+                node2 = Node::new(
+                    &sodium_ctx2,
+                    "switch_s outer node",
+                    move || {
+                        csa_updates.with_firing_op(|firing_op: &mut Option<Stream<A>>| {
+                            if let Some(ref firing) = firing_op {
+                                let firing = firing.clone();
+                                let node1 = node1.clone();
+                                let inner_s = inner_s.clone();
+                                sodium_ctx.pre_post(move || {
+                                    let mut l = inner_s.lock();
+                                    let inner_s: &mut WeakStream<A> = l.as_mut().unwrap();
+                                    IsNode::remove_dependency(&node1, &inner_s.upgrade().unwrap());
+                                    IsNode::add_dependency(&node1, firing.clone());
+                                    *inner_s = Stream::downgrade(&firing);
+                                });
+                            }
+                        });
+                    },
+                    vec![csa_updates_node.box_clone()],
+                );
+            }
+            IsNode::add_update_dependencies(
+                &node2,
+                vec![csa_updates_dep, Dep::new(node1.gc_node().clone())],
+            );
+            IsNode::add_dependency(&node1, node2);
+            node1
+        })
+    }
+
+    pub fn switch_c(cca: &Cell<Cell<A>>) -> Cell<A>
+    where
+        A: Clone,
+    {
         let cca2 = cca.clone();
         let cca = cca.clone();
         let sodium_ctx = cca.sodium_ctx();
-        Stream::_new(
-            &sodium_ctx,
-            |sa: StreamWeakForwardRef<A>| {
-                let node1 = Node::new(
-                    &sodium_ctx,
-                    "switch_c outer node",
-                    || {},
-                    vec![cca.updates().box_clone()]
-                );
-                let init_inner_s = cca.sample().updates();
-                let last_inner_s = Arc::new(Mutex::new(Stream::downgrade(&init_inner_s)));
-                let node2 = Node::new(
-                    &sodium_ctx,
-                    "switch_c inner node",
-                    || {},
-                    vec![node1.box_clone(), init_inner_s.box_clone()]
-                );
-                let node1_update;
-                {
-                    let sodium_ctx = sodium_ctx.clone();
-                    let node1 = node1.clone();
-                    let node2 = node2.clone();
-                    let cca = cca.clone();
-                    let sa = sa.clone();
-                    let last_inner_s = last_inner_s.clone();
-                    node1_update = move || {
-                        cca.updates().with_firing_op(|firing_op: &mut Option<Cell<A>>| {
+        Stream::_new(&sodium_ctx, |sa: StreamWeakForwardRef<A>| {
+            let node1 = Node::new(
+                &sodium_ctx,
+                "switch_c outer node",
+                || {},
+                vec![cca.updates().box_clone()],
+            );
+            let init_inner_s = cca.sample().updates();
+            let last_inner_s = Arc::new(Mutex::new(Stream::downgrade(&init_inner_s)));
+            let node2 = Node::new(
+                &sodium_ctx,
+                "switch_c inner node",
+                || {},
+                vec![node1.box_clone(), init_inner_s.box_clone()],
+            );
+            let node1_update;
+            {
+                let sodium_ctx = sodium_ctx.clone();
+                let node1 = node1.clone();
+                let node2 = node2.clone();
+                let cca = cca.clone();
+                let sa = sa.clone();
+                let last_inner_s = last_inner_s.clone();
+                node1_update = move || {
+                    cca.updates()
+                        .with_firing_op(|firing_op: &mut Option<Cell<A>>| {
                             if let Some(ref firing) = firing_op {
                                 // will be overwriten by node2 firing if there is one
                                 sodium_ctx.update_node(&firing.updates().node());
@@ -480,7 +549,10 @@ impl<A:Send+'static> Cell<A> {
                                 });
                                 let mut l = last_inner_s.lock();
                                 let last_inner_s: &mut WeakStream<A> = l.as_mut().unwrap();
-                                IsNode::remove_dependency(&node2, last_inner_s.upgrade().unwrap().node());
+                                IsNode::remove_dependency(
+                                    &node2,
+                                    last_inner_s.upgrade().unwrap().node(),
+                                );
                                 IsNode::add_dependency(&node2, new_inner_s.clone());
                                 {
                                     let mut changed = node2.data.changed.write().unwrap();
@@ -489,53 +561,61 @@ impl<A:Send+'static> Cell<A> {
                                 *last_inner_s = Stream::downgrade(&new_inner_s);
                             }
                         });
-                    };
-                }
-                IsNode::add_update_dependencies(&node1, vec![Dep::new(node1.gc_node.clone()), Dep::new(node2.gc_node.clone())]);
-                {
-                    let mut update = node1.data.update.write().unwrap();
-                    *update = Box::new(node1_update);
-                }
-                {
-                    let last_inner_s = last_inner_s;
-                    let node2_update = move || {
-                        let l = last_inner_s.lock();
-                        let last_inner_s: &WeakStream<A> = l.as_ref().unwrap();
-                        let last_inner_s = last_inner_s.upgrade().unwrap();
-                        last_inner_s.with_firing_op(|firing_op: &mut Option<A>| {
-                            if let Some(ref firing) = firing_op {
-                                let sa = sa.unwrap();
-                                sa._send(firing.clone());
-                            }
-                        });
-                    };
-                    {
-                        let mut update = node2.data.update.write().unwrap();
-                        *update = Box::new(node2_update);
-                    }
-                }
-                node2
+                };
             }
-        )
+            IsNode::add_update_dependencies(
+                &node1,
+                vec![
+                    Dep::new(node1.gc_node.clone()),
+                    Dep::new(node2.gc_node.clone()),
+                ],
+            );
+            {
+                let mut update = node1.data.update.write().unwrap();
+                *update = Box::new(node1_update);
+            }
+            {
+                let last_inner_s = last_inner_s;
+                let node2_update = move || {
+                    let l = last_inner_s.lock();
+                    let last_inner_s: &WeakStream<A> = l.as_ref().unwrap();
+                    let last_inner_s = last_inner_s.upgrade().unwrap();
+                    last_inner_s.with_firing_op(|firing_op: &mut Option<A>| {
+                        if let Some(ref firing) = firing_op {
+                            let sa = sa.unwrap();
+                            sa._send(firing.clone());
+                        }
+                    });
+                };
+                {
+                    let mut update = node2.data.update.write().unwrap();
+                    *update = Box::new(node2_update);
+                }
+            }
+            node2
+        })
         .hold_lazy(Lazy::new(move || cca2.sample().sample()))
     }
 
-    pub fn listen_weak<K: FnMut(&A)+Send+Sync+'static>(&self, k: K) -> Listener where A: Clone {
-        self.sodium_ctx().transaction(|| {
-            self.value().listen_weak(k)
-        })
+    pub fn listen_weak<K: FnMut(&A) + Send + Sync + 'static>(&self, k: K) -> Listener
+    where
+        A: Clone,
+    {
+        self.sodium_ctx()
+            .transaction(|| self.value().listen_weak(k))
     }
 
-    pub fn listen<K:IsLambda1<A,()>+Send+Sync+'static>(&self, k: K) -> Listener where A: Clone {
-        self.sodium_ctx().transaction(|| {
-            self.value().listen(k)
-        })
+    pub fn listen<K: IsLambda1<A, ()> + Send + Sync + 'static>(&self, k: K) -> Listener
+    where
+        A: Clone,
+    {
+        self.sodium_ctx().transaction(|| self.value().listen(k))
     }
 
     pub fn downgrade(this: &Self) -> WeakCell<A> {
         WeakCell {
             data: Arc::downgrade(&this.data),
-            node: Node::downgrade2(&this.node)
+            node: Node::downgrade2(&this.node),
         }
     }
 }

--- a/src/impl_/cell_loop.rs
+++ b/src/impl_/cell_loop.rs
@@ -18,13 +18,12 @@ impl<A> Clone for CellLoop<A> {
         CellLoop {
             init_value_op: self.init_value_op.clone(),
             stream_loop: self.stream_loop.clone(),
-            cell: self.cell.clone()
+            cell: self.cell.clone(),
         }
     }
 }
 
-impl<A:Send+Clone+'static> CellLoop<A> {
-
+impl<A: Send + Clone + 'static> CellLoop<A> {
     pub fn new(sodium_ctx: &SodiumCtx) -> CellLoop<A> {
         let init_value_op: Arc<Mutex<Option<A>>> = Arc::new(Mutex::new(None));
         let init_value: Lazy<A>;

--- a/src/impl_/cell_sink.rs
+++ b/src/impl_/cell_sink.rs
@@ -4,24 +4,24 @@ use crate::impl_::stream_sink::StreamSink;
 
 pub struct CellSink<A> {
     cell: Cell<A>,
-    stream_sink: StreamSink<A>
+    stream_sink: StreamSink<A>,
 }
 
 impl<A> Clone for CellSink<A> {
     fn clone(&self) -> Self {
         CellSink {
             cell: self.cell.clone(),
-            stream_sink: self.stream_sink.clone()
+            stream_sink: self.stream_sink.clone(),
         }
     }
 }
 
-impl<A:Send+Clone+'static> CellSink<A> {
+impl<A: Send + Clone + 'static> CellSink<A> {
     pub fn new(sodium_ctx: &SodiumCtx, a: A) -> CellSink<A> {
         let stream_sink = StreamSink::new(sodium_ctx);
         CellSink {
             cell: stream_sink.stream().hold(a),
-            stream_sink
+            stream_sink,
         }
     }
 

--- a/src/impl_/dep.rs
+++ b/src/impl_/dep.rs
@@ -2,14 +2,12 @@ use crate::impl_::gc_node::GcNode;
 
 #[derive(Clone)]
 pub struct Dep {
-    gc_node: GcNode
+    gc_node: GcNode,
 }
 
 impl Dep {
     pub fn new(gc_node: GcNode) -> Dep {
-        Dep {
-            gc_node
-        }
+        Dep { gc_node }
     }
 
     pub fn gc_node(&self) -> &GcNode {

--- a/src/impl_/lambda.rs
+++ b/src/impl_/lambda.rs
@@ -4,65 +4,64 @@ use crate::impl_::dep::Dep;
 
 pub struct Lambda<FN> {
     f: FN,
-    deps: Vec<Dep>
+    deps: Vec<Dep>,
 }
 
-pub fn lambda1_deps<A,B,FN:IsLambda1<A,B>>(f: &FN) -> Vec<Dep> {
+pub fn lambda1_deps<A, B, FN: IsLambda1<A, B>>(f: &FN) -> Vec<Dep> {
     f.deps_op().cloned().unwrap_or_else(Vec::new)
 }
 
-pub fn lambda2_deps<A,B,C,FN:IsLambda2<A,B,C>>(f: &FN) -> Vec<Dep> {
+pub fn lambda2_deps<A, B, C, FN: IsLambda2<A, B, C>>(f: &FN) -> Vec<Dep> {
     f.deps_op().cloned().unwrap_or_else(Vec::new)
 }
 
-pub fn lambda3_deps<A,B,C,D,FN:IsLambda3<A,B,C,D>>(f: &FN) -> Vec<Dep> {
+pub fn lambda3_deps<A, B, C, D, FN: IsLambda3<A, B, C, D>>(f: &FN) -> Vec<Dep> {
     f.deps_op().cloned().unwrap_or_else(Vec::new)
 }
 
-pub fn lambda4_deps<A,B,C,D,E,FN:IsLambda4<A,B,C,D,E>>(f: &FN) -> Vec<Dep> {
+pub fn lambda4_deps<A, B, C, D, E, FN: IsLambda4<A, B, C, D, E>>(f: &FN) -> Vec<Dep> {
     f.deps_op().cloned().unwrap_or_else(Vec::new)
 }
 
-pub fn lambda5_deps<A,B,C,D,E,F,FN:IsLambda5<A,B,C,D,E,F>>(f: &FN) -> Vec<Dep> {
+pub fn lambda5_deps<A, B, C, D, E, F, FN: IsLambda5<A, B, C, D, E, F>>(f: &FN) -> Vec<Dep> {
     f.deps_op().cloned().unwrap_or_else(Vec::new)
 }
 
-pub fn lambda6_deps<A,B,C,D,E,F,G,FN:IsLambda6<A,B,C,D,E,F,G>>(f: &FN) -> Vec<Dep> {
+pub fn lambda6_deps<A, B, C, D, E, F, G, FN: IsLambda6<A, B, C, D, E, F, G>>(f: &FN) -> Vec<Dep> {
     f.deps_op().cloned().unwrap_or_else(Vec::new)
 }
 
-pub trait IsLambda1<A,B> {
+pub trait IsLambda1<A, B> {
     fn call(&mut self, a: &A) -> B;
     fn deps_op(&self) -> Option<&Vec<Dep>>;
 }
 
-pub trait IsLambda2<A,B,C> {
+pub trait IsLambda2<A, B, C> {
     fn call(&mut self, a: &A, b: &B) -> C;
     fn deps_op(&self) -> Option<&Vec<Dep>>;
 }
 
-pub trait IsLambda3<A,B,C,D> {
+pub trait IsLambda3<A, B, C, D> {
     fn call(&mut self, a: &A, b: &B, c: &C) -> D;
     fn deps_op(&self) -> Option<&Vec<Dep>>;
 }
 
-pub trait IsLambda4<A,B,C,D,E> {
+pub trait IsLambda4<A, B, C, D, E> {
     fn call(&mut self, a: &A, b: &B, c: &C, d: &D) -> E;
     fn deps_op(&self) -> Option<&Vec<Dep>>;
 }
 
-pub trait IsLambda5<A,B,C,D,E,F> {
+pub trait IsLambda5<A, B, C, D, E, F> {
     fn call(&mut self, a: &A, b: &B, c: &C, d: &D, e: &E) -> F;
     fn deps_op(&self) -> Option<&Vec<Dep>>;
 }
 
-pub trait IsLambda6<A,B,C,D,E,F,G> {
+pub trait IsLambda6<A, B, C, D, E, F, G> {
     fn call(&mut self, a: &A, b: &B, c: &C, d: &D, e: &E, f: &F) -> G;
     fn deps_op(&self) -> Option<&Vec<Dep>>;
 }
 
-impl<A,B,FN:FnMut(&A)->B> IsLambda1<A,B> for Lambda<FN> {
-
+impl<A, B, FN: FnMut(&A) -> B> IsLambda1<A, B> for Lambda<FN> {
     fn call(&mut self, a: &A) -> B {
         (self.f)(a)
     }
@@ -72,8 +71,7 @@ impl<A,B,FN:FnMut(&A)->B> IsLambda1<A,B> for Lambda<FN> {
     }
 }
 
-impl<A,B,FN:FnMut(&A)->B> IsLambda1<A,B> for FN {
-
+impl<A, B, FN: FnMut(&A) -> B> IsLambda1<A, B> for FN {
     fn call(&mut self, a: &A) -> B {
         self(a)
     }
@@ -83,10 +81,9 @@ impl<A,B,FN:FnMut(&A)->B> IsLambda1<A,B> for FN {
     }
 }
 
-impl<A,B,C,FN:FnMut(&A,&B)->C> IsLambda2<A,B,C> for Lambda<FN> {
-
+impl<A, B, C, FN: FnMut(&A, &B) -> C> IsLambda2<A, B, C> for Lambda<FN> {
     fn call(&mut self, a: &A, b: &B) -> C {
-        (self.f)(a,b)
+        (self.f)(a, b)
     }
 
     fn deps_op(&self) -> Option<&Vec<Dep>> {
@@ -94,10 +91,9 @@ impl<A,B,C,FN:FnMut(&A,&B)->C> IsLambda2<A,B,C> for Lambda<FN> {
     }
 }
 
-impl<A,B,C,FN:FnMut(&A,&B)->C> IsLambda2<A,B,C> for FN {
-
+impl<A, B, C, FN: FnMut(&A, &B) -> C> IsLambda2<A, B, C> for FN {
     fn call(&mut self, a: &A, b: &B) -> C {
-        self(a,b)
+        self(a, b)
     }
 
     fn deps_op(&self) -> Option<&Vec<Dep>> {
@@ -105,10 +101,9 @@ impl<A,B,C,FN:FnMut(&A,&B)->C> IsLambda2<A,B,C> for FN {
     }
 }
 
-impl<A,B,C,D,FN:FnMut(&A,&B,&C)->D> IsLambda3<A,B,C,D> for Lambda<FN> {
-
+impl<A, B, C, D, FN: FnMut(&A, &B, &C) -> D> IsLambda3<A, B, C, D> for Lambda<FN> {
     fn call(&mut self, a: &A, b: &B, c: &C) -> D {
-        (self.f)(a,b,c)
+        (self.f)(a, b, c)
     }
 
     fn deps_op(&self) -> Option<&Vec<Dep>> {
@@ -116,10 +111,9 @@ impl<A,B,C,D,FN:FnMut(&A,&B,&C)->D> IsLambda3<A,B,C,D> for Lambda<FN> {
     }
 }
 
-impl<A,B,C,D,FN:FnMut(&A,&B,&C)->D> IsLambda3<A,B,C,D> for FN {
-
+impl<A, B, C, D, FN: FnMut(&A, &B, &C) -> D> IsLambda3<A, B, C, D> for FN {
     fn call(&mut self, a: &A, b: &B, c: &C) -> D {
-        self(a,b,c)
+        self(a, b, c)
     }
 
     fn deps_op(&self) -> Option<&Vec<Dep>> {
@@ -127,10 +121,9 @@ impl<A,B,C,D,FN:FnMut(&A,&B,&C)->D> IsLambda3<A,B,C,D> for FN {
     }
 }
 
-impl<A,B,C,D,E,FN:FnMut(&A,&B,&C,&D)->E> IsLambda4<A,B,C,D,E> for Lambda<FN> {
-
+impl<A, B, C, D, E, FN: FnMut(&A, &B, &C, &D) -> E> IsLambda4<A, B, C, D, E> for Lambda<FN> {
     fn call(&mut self, a: &A, b: &B, c: &C, d: &D) -> E {
-        (self.f)(a,b,c,d)
+        (self.f)(a, b, c, d)
     }
 
     fn deps_op(&self) -> Option<&Vec<Dep>> {
@@ -138,10 +131,9 @@ impl<A,B,C,D,E,FN:FnMut(&A,&B,&C,&D)->E> IsLambda4<A,B,C,D,E> for Lambda<FN> {
     }
 }
 
-impl<A,B,C,D,E,FN:FnMut(&A,&B,&C,&D)->E> IsLambda4<A,B,C,D,E> for FN {
-
+impl<A, B, C, D, E, FN: FnMut(&A, &B, &C, &D) -> E> IsLambda4<A, B, C, D, E> for FN {
     fn call(&mut self, a: &A, b: &B, c: &C, d: &D) -> E {
-        self(a,b,c,d)
+        self(a, b, c, d)
     }
 
     fn deps_op(&self) -> Option<&Vec<Dep>> {
@@ -149,10 +141,11 @@ impl<A,B,C,D,E,FN:FnMut(&A,&B,&C,&D)->E> IsLambda4<A,B,C,D,E> for FN {
     }
 }
 
-impl<A,B,C,D,E,F,FN:FnMut(&A,&B,&C,&D,&E)->F> IsLambda5<A,B,C,D,E,F> for Lambda<FN> {
-
+impl<A, B, C, D, E, F, FN: FnMut(&A, &B, &C, &D, &E) -> F> IsLambda5<A, B, C, D, E, F>
+    for Lambda<FN>
+{
     fn call(&mut self, a: &A, b: &B, c: &C, d: &D, e: &E) -> F {
-        (self.f)(a,b,c,d,e)
+        (self.f)(a, b, c, d, e)
     }
 
     fn deps_op(&self) -> Option<&Vec<Dep>> {
@@ -160,10 +153,9 @@ impl<A,B,C,D,E,F,FN:FnMut(&A,&B,&C,&D,&E)->F> IsLambda5<A,B,C,D,E,F> for Lambda<
     }
 }
 
-impl<A,B,C,D,E,F,FN:FnMut(&A,&B,&C,&D,&E)->F> IsLambda5<A,B,C,D,E,F> for FN {
-
+impl<A, B, C, D, E, F, FN: FnMut(&A, &B, &C, &D, &E) -> F> IsLambda5<A, B, C, D, E, F> for FN {
     fn call(&mut self, a: &A, b: &B, c: &C, d: &D, e: &E) -> F {
-        self(a,b,c,d,e)
+        self(a, b, c, d, e)
     }
 
     fn deps_op(&self) -> Option<&Vec<Dep>> {
@@ -171,10 +163,11 @@ impl<A,B,C,D,E,F,FN:FnMut(&A,&B,&C,&D,&E)->F> IsLambda5<A,B,C,D,E,F> for FN {
     }
 }
 
-impl<A,B,C,D,E,F,G,FN:FnMut(&A,&B,&C,&D,&E,&F)->G> IsLambda6<A,B,C,D,E,F,G> for Lambda<FN> {
-
+impl<A, B, C, D, E, F, G, FN: FnMut(&A, &B, &C, &D, &E, &F) -> G> IsLambda6<A, B, C, D, E, F, G>
+    for Lambda<FN>
+{
     fn call(&mut self, a: &A, b: &B, c: &C, d: &D, e: &E, f: &F) -> G {
-        (self.f)(a,b,c,d,e,f)
+        (self.f)(a, b, c, d, e, f)
     }
 
     fn deps_op(&self) -> Option<&Vec<Dep>> {
@@ -182,10 +175,11 @@ impl<A,B,C,D,E,F,G,FN:FnMut(&A,&B,&C,&D,&E,&F)->G> IsLambda6<A,B,C,D,E,F,G> for 
     }
 }
 
-impl<A,B,C,D,E,F,G,FN:FnMut(&A,&B,&C,&D,&E,&F)->G> IsLambda6<A,B,C,D,E,F,G> for FN {
-
+impl<A, B, C, D, E, F, G, FN: FnMut(&A, &B, &C, &D, &E, &F) -> G> IsLambda6<A, B, C, D, E, F, G>
+    for FN
+{
     fn call(&mut self, a: &A, b: &B, c: &C, d: &D, e: &E, f: &F) -> G {
-        self(a,b,c,d,e,f)
+        self(a, b, c, d, e, f)
     }
 
     fn deps_op(&self) -> Option<&Vec<Dep>> {
@@ -193,26 +187,32 @@ impl<A,B,C,D,E,F,G,FN:FnMut(&A,&B,&C,&D,&E,&F)->G> IsLambda6<A,B,C,D,E,F,G> for 
     }
 }
 
-pub fn lambda1<A,B,FN:FnMut(&A)->B>(f: FN, deps: Vec<Dep>) -> Lambda<FN> {
+pub fn lambda1<A, B, FN: FnMut(&A) -> B>(f: FN, deps: Vec<Dep>) -> Lambda<FN> {
     Lambda { f, deps }
 }
 
-pub fn lambda2<A,B,C,FN:FnMut(&A,&B)->C>(f: FN, deps: Vec<Dep>) -> Lambda<FN> {
+pub fn lambda2<A, B, C, FN: FnMut(&A, &B) -> C>(f: FN, deps: Vec<Dep>) -> Lambda<FN> {
     Lambda { f, deps }
 }
 
-pub fn lambda3<A,B,C,D,FN:FnMut(&A,&B,&C)->D>(f: FN, deps: Vec<Dep>) -> Lambda<FN> {
+pub fn lambda3<A, B, C, D, FN: FnMut(&A, &B, &C) -> D>(f: FN, deps: Vec<Dep>) -> Lambda<FN> {
     Lambda { f, deps }
 }
 
-pub fn lambda4<A,B,C,D,E,FN:FnMut(&A,&B,&C,&D)->E>(f: FN, deps: Vec<Dep>) -> Lambda<FN> {
+pub fn lambda4<A, B, C, D, E, FN: FnMut(&A, &B, &C, &D) -> E>(f: FN, deps: Vec<Dep>) -> Lambda<FN> {
     Lambda { f, deps }
 }
 
-pub fn lambda5<A,B,C,D,E,F,FN:FnMut(&A,&B,&C,&D,&E)->F>(f: FN, deps: Vec<Dep>) -> Lambda<FN> {
+pub fn lambda5<A, B, C, D, E, F, FN: FnMut(&A, &B, &C, &D, &E) -> F>(
+    f: FN,
+    deps: Vec<Dep>,
+) -> Lambda<FN> {
     Lambda { f, deps }
 }
 
-pub fn lambda6<A,B,C,D,E,F,G,FN:FnMut(&A,&B,&C,&D,&E,&F)->G>(f: FN, deps: Vec<Dep>) -> Lambda<FN> {
+pub fn lambda6<A, B, C, D, E, F, G, FN: FnMut(&A, &B, &C, &D, &E, &F) -> G>(
+    f: FN,
+    deps: Vec<Dep>,
+) -> Lambda<FN> {
     Lambda { f, deps }
 }

--- a/src/impl_/lazy.rs
+++ b/src/impl_/lazy.rs
@@ -2,33 +2,32 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 pub struct Lazy<A> {
-    data: Arc<Mutex<LazyData<A>>>
+    data: Arc<Mutex<LazyData<A>>>,
 }
 
 impl<A> Clone for Lazy<A> {
     fn clone(&self) -> Self {
         Lazy {
-            data: self.data.clone()
+            data: self.data.clone(),
         }
     }
 }
 
 pub enum LazyData<A> {
-    Thunk(Box<dyn FnMut()->A+Send>),
-    Value(A)
+    Thunk(Box<dyn FnMut() -> A + Send>),
+    Value(A),
 }
 
-impl<A:Send+Clone+'static> Lazy<A> {
-
-    pub fn new<THUNK:FnMut()->A+Send+'static>(thunk: THUNK) -> Lazy<A> {
+impl<A: Send + Clone + 'static> Lazy<A> {
+    pub fn new<THUNK: FnMut() -> A + Send + 'static>(thunk: THUNK) -> Lazy<A> {
         Lazy {
-            data: Arc::new(Mutex::new(LazyData::Thunk(Box::new(thunk))))
+            data: Arc::new(Mutex::new(LazyData::Thunk(Box::new(thunk)))),
         }
     }
 
     pub fn of_value(value: A) -> Lazy<A> {
         Lazy {
-            data: Arc::new(Mutex::new(LazyData::Value(value)))
+            data: Arc::new(Mutex::new(LazyData::Value(value))),
         }
     }
 
@@ -41,7 +40,7 @@ impl<A:Send+Clone+'static> Lazy<A> {
             LazyData::Thunk(ref mut k) => {
                 result = k();
                 next_op = Some(LazyData::Value(result.clone()));
-            },
+            }
             LazyData::Value(ref x) => {
                 result = x.clone();
                 next_op = None;

--- a/src/impl_/stream.rs
+++ b/src/impl_/stream.rs
@@ -1,42 +1,42 @@
 use crate::impl_::cell::Cell;
 use crate::impl_::dep::Dep;
-use crate::impl_::node::{Node, WeakNode, IsNode, IsWeakNode, box_clone_vec_is_node};
-use crate::impl_::lazy::Lazy;
-use crate::impl_::listener::Listener;
-use crate::impl_::sodium_ctx::SodiumCtx;
-use crate::impl_::stream_loop::StreamLoop;
-use crate::impl_::stream_sink::StreamSink;
 use crate::impl_::lambda::IsLambda1;
 use crate::impl_::lambda::IsLambda2;
 use crate::impl_::lambda::{lambda1, lambda1_deps, lambda2_deps};
+use crate::impl_::lazy::Lazy;
+use crate::impl_::listener::Listener;
+use crate::impl_::node::{box_clone_vec_is_node, IsNode, IsWeakNode, Node, WeakNode};
+use crate::impl_::sodium_ctx::SodiumCtx;
+use crate::impl_::stream_loop::StreamLoop;
+use crate::impl_::stream_sink::StreamSink;
 
 use std::sync::Arc;
-use std::sync::RwLock;
 use std::sync::Mutex;
+use std::sync::RwLock;
 use std::sync::Weak;
 
 pub struct StreamWeakForwardRef<A> {
-    data: Arc<RwLock<Option<WeakStream<A>>>>
+    data: Arc<RwLock<Option<WeakStream<A>>>>,
 }
 
 impl<A> Clone for StreamWeakForwardRef<A> {
     fn clone(&self) -> Self {
         StreamWeakForwardRef {
-            data: self.data.clone()
+            data: self.data.clone(),
         }
     }
 }
 
-impl<A: Send+'static> Default for StreamWeakForwardRef<A> {
+impl<A: Send + 'static> Default for StreamWeakForwardRef<A> {
     fn default() -> StreamWeakForwardRef<A> {
         StreamWeakForwardRef::new()
     }
 }
 
-impl<A:Send+'static> StreamWeakForwardRef<A> {
+impl<A: Send + 'static> StreamWeakForwardRef<A> {
     pub fn new() -> StreamWeakForwardRef<A> {
         StreamWeakForwardRef {
-            data: Arc::new(RwLock::new(None))
+            data: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -53,15 +53,15 @@ impl<A:Send+'static> StreamWeakForwardRef<A> {
 
 pub struct Stream<A> {
     pub data: Arc<Mutex<StreamData<A>>>,
-    pub node: Node
+    pub node: Node,
 }
 
 pub struct WeakStream<A> {
     pub data: Weak<Mutex<StreamData<A>>>,
-    pub node: WeakNode
+    pub node: WeakNode,
 }
 
-impl<A:Send+'static> IsNode for Stream<A> {
+impl<A: Send + 'static> IsNode for Stream<A> {
     fn node(&self) -> &Node {
         &self.node
     }
@@ -75,7 +75,7 @@ impl<A:Send+'static> IsNode for Stream<A> {
     }
 }
 
-impl<A:Send+'static> IsWeakNode for WeakStream<A> {
+impl<A: Send + 'static> IsWeakNode for WeakStream<A> {
     fn node(&self) -> &WeakNode {
         &self.node
     }
@@ -93,7 +93,7 @@ impl<A> Clone for Stream<A> {
     fn clone(&self) -> Self {
         Stream {
             data: self.data.clone(),
-            node: self.node.clone()
+            node: self.node.clone(),
         }
     }
 }
@@ -102,7 +102,7 @@ impl<A> Clone for WeakStream<A> {
     fn clone(&self) -> Self {
         WeakStream {
             data: self.data.clone(),
-            node: self.node.clone()
+            node: self.node.clone(),
         }
     }
 }
@@ -110,17 +110,17 @@ impl<A> Clone for WeakStream<A> {
 pub struct StreamData<A> {
     pub firing_op: Option<A>,
     pub sodium_ctx: SodiumCtx,
-    pub coalescer_op: Option<Box<dyn FnMut(&A,&A)->A+Send>>
+    pub coalescer_op: Option<Box<dyn FnMut(&A, &A) -> A + Send>>,
 }
 
 impl<A> Stream<A> {
-    pub fn with_data<R,K:FnOnce(&mut StreamData<A>)->R>(&self, k: K) -> R {
+    pub fn with_data<R, K: FnOnce(&mut StreamData<A>) -> R>(&self, k: K) -> R {
         let mut l = self.data.lock();
         let data: &mut StreamData<A> = l.as_mut().unwrap();
         k(data)
     }
 
-    pub fn with_firing_op<R,K:FnOnce(&mut Option<A>)->R>(&self, k: K) -> R {
+    pub fn with_firing_op<R, K: FnOnce(&mut Option<A>) -> R>(&self, k: K) -> R {
         self.with_data(|data: &mut StreamData<A>| k(&mut data.firing_op))
     }
 
@@ -135,44 +135,36 @@ impl<A> Stream<A> {
     pub fn sodium_ctx(&self) -> SodiumCtx {
         self.with_data(|data: &mut StreamData<A>| data.sodium_ctx.clone())
     }
-
 }
 
-impl<A:Send+'static> Stream<A> {
+impl<A: Send + 'static> Stream<A> {
     pub fn new(sodium_ctx: &SodiumCtx) -> Stream<A> {
-        Stream::_new(
-            sodium_ctx,
-            |_s: StreamWeakForwardRef<A>| {
-                Node::new(
-                    sodium_ctx,
-                    "Stream::new",
-                    || {},
-                    Vec::new()
-                )
-            }
-        )
+        Stream::_new(sodium_ctx, |_s: StreamWeakForwardRef<A>| {
+            Node::new(sodium_ctx, "Stream::new", || {}, Vec::new())
+        })
     }
 
     // for purpose of capturing stream in lambda
     pub fn nop(&self) {}
 
-    pub fn _new_with_coalescer<COALESCER:FnMut(&A,&A)->A+Send+'static>(sodium_ctx: &SodiumCtx, coalescer: COALESCER) -> Stream<A> {
+    pub fn _new_with_coalescer<COALESCER: FnMut(&A, &A) -> A + Send + 'static>(
+        sodium_ctx: &SodiumCtx,
+        coalescer: COALESCER,
+    ) -> Stream<A> {
         Stream {
             data: Arc::new(Mutex::new(StreamData {
                 firing_op: None,
                 sodium_ctx: sodium_ctx.clone(),
-                coalescer_op: Some(Box::new(coalescer))
+                coalescer_op: Some(Box::new(coalescer)),
             })),
-            node: Node::new(
-                &sodium_ctx,
-                "Stream::_new_with_coalescer",
-                || {},
-                vec![]
-            )
+            node: Node::new(&sodium_ctx, "Stream::_new_with_coalescer", || {}, vec![]),
         }
     }
 
-    pub fn _new<MkNode:FnOnce(StreamWeakForwardRef<A>)->Node>(sodium_ctx: &SodiumCtx, mk_node: MkNode) -> Stream<A> {
+    pub fn _new<MkNode: FnOnce(StreamWeakForwardRef<A>) -> Node>(
+        sodium_ctx: &SodiumCtx,
+        mk_node: MkNode,
+    ) -> Stream<A> {
         let result_forward_ref: StreamWeakForwardRef<A> = StreamWeakForwardRef::new();
         let s;
         let node = mk_node(result_forward_ref.clone());
@@ -181,9 +173,9 @@ impl<A:Send+'static> Stream<A> {
                 data: Arc::new(Mutex::new(StreamData {
                     firing_op: None,
                     sodium_ctx: sodium_ctx.clone(),
-                    coalescer_op: None
+                    coalescer_op: None,
                 })),
-                node: node.clone()
+                node: node.clone(),
             };
         }
         result_forward_ref.assign(&s);
@@ -192,8 +184,7 @@ impl<A:Send+'static> Stream<A> {
             let update: &mut Box<_> = &mut update;
             update();
         }
-        let is_firing =
-            s.with_data(|data: &mut StreamData<A>| data.firing_op.is_some());
+        let is_firing = s.with_data(|data: &mut StreamData<A>| data.firing_op.is_some());
         if is_firing {
             {
                 let s_node = s.node();
@@ -213,129 +204,150 @@ impl<A:Send+'static> Stream<A> {
         s
     }
 
-    pub fn snapshot<B:Send+Clone+'static,C:Send+'static,FN:IsLambda2<A,B,C>+Send+Sync+'static>(&self, cb: &Cell<B>, mut f: FN) -> Stream<C> {
+    pub fn snapshot<
+        B: Send + Clone + 'static,
+        C: Send + 'static,
+        FN: IsLambda2<A, B, C> + Send + Sync + 'static,
+    >(
+        &self,
+        cb: &Cell<B>,
+        mut f: FN,
+    ) -> Stream<C> {
         let cb = cb.clone();
         let mut f_deps = lambda2_deps(&f);
         f_deps.push(Dep::new(cb.node().gc_node().clone()));
         self.map(lambda1(move |a: &A| f.call(a, &cb.sample()), f_deps))
     }
 
-    pub fn snapshot1<B:Send+Clone+'static>(&self, cb: &Cell<B>) -> Stream<B> {
+    pub fn snapshot1<B: Send + Clone + 'static>(&self, cb: &Cell<B>) -> Stream<B> {
         self.snapshot(cb, |_a: &A, b: &B| b.clone())
     }
 
-    pub fn map<B:Send+'static,FN:IsLambda1<A,B>+Send+Sync+'static>(&self, mut f: FN) -> Stream<B> {
+    pub fn map<B: Send + 'static, FN: IsLambda1<A, B> + Send + Sync + 'static>(
+        &self,
+        mut f: FN,
+    ) -> Stream<B> {
         let self_ = self.clone();
         let sodium_ctx = self.sodium_ctx();
-        Stream::_new(
-            &sodium_ctx,
-            |s: StreamWeakForwardRef<B>| {
-                let f_deps = lambda1_deps(&f);
-                let node = Node::new(
-                    &sodium_ctx,
-                    "Stream::map",
-                    move || {
-                        self_.with_firing_op(|firing_op: &mut Option<A>| {
-                            if let Some(ref firing) = firing_op {
-                                s.unwrap()._send(f.call(firing));
-                            }
-                        })
-                    },
-                    vec![self.box_clone()]
-                );
-                IsNode::add_update_dependencies(&node, f_deps);
-                IsNode::add_update_dependencies(&node, vec![self.to_dep()]);
-                node
-            }
-        )
+        Stream::_new(&sodium_ctx, |s: StreamWeakForwardRef<B>| {
+            let f_deps = lambda1_deps(&f);
+            let node = Node::new(
+                &sodium_ctx,
+                "Stream::map",
+                move || {
+                    self_.with_firing_op(|firing_op: &mut Option<A>| {
+                        if let Some(ref firing) = firing_op {
+                            s.unwrap()._send(f.call(firing));
+                        }
+                    })
+                },
+                vec![self.box_clone()],
+            );
+            IsNode::add_update_dependencies(&node, f_deps);
+            IsNode::add_update_dependencies(&node, vec![self.to_dep()]);
+            node
+        })
     }
 
-    pub fn filter<PRED:IsLambda1<A,bool>+Send+Sync+'static>(&self, mut pred: PRED) -> Stream<A> where A: Clone {
+    pub fn filter<PRED: IsLambda1<A, bool> + Send + Sync + 'static>(
+        &self,
+        mut pred: PRED,
+    ) -> Stream<A>
+    where
+        A: Clone,
+    {
         let self_ = self.clone();
         let sodium_ctx = self.sodium_ctx();
-        Stream::_new(
-            &sodium_ctx,
-            |s: StreamWeakForwardRef<A>| {
-                let pred_deps = lambda1_deps(&pred);
-                let node = Node::new(
-                    &sodium_ctx,
-                    "Stream::filter",
-                    move || {
-                        self_.with_firing_op(|firing_op: &mut Option<A>| {
-                            let firing_op2 = firing_op.clone().filter(|firing| pred.call(firing));
-                            if let Some(firing) = firing_op2 {
-                                s.unwrap()._send(firing);
-                            }
-                        });
-                    },
-                    vec![self.box_clone()]
-                );
-                IsNode::add_update_dependencies(&node, pred_deps);
-                IsNode::add_update_dependencies(&node, vec![self.to_dep()]);
-                node
-            }
-        )
+        Stream::_new(&sodium_ctx, |s: StreamWeakForwardRef<A>| {
+            let pred_deps = lambda1_deps(&pred);
+            let node = Node::new(
+                &sodium_ctx,
+                "Stream::filter",
+                move || {
+                    self_.with_firing_op(|firing_op: &mut Option<A>| {
+                        let firing_op2 = firing_op.clone().filter(|firing| pred.call(firing));
+                        if let Some(firing) = firing_op2 {
+                            s.unwrap()._send(firing);
+                        }
+                    });
+                },
+                vec![self.box_clone()],
+            );
+            IsNode::add_update_dependencies(&node, pred_deps);
+            IsNode::add_update_dependencies(&node, vec![self.to_dep()]);
+            node
+        })
     }
 
-    pub fn or_else(&self, s2: &Stream<A>) -> Stream<A> where A: Clone {
-        self.merge(s2, |lhs:&A, _rhs:&A| lhs.clone())
+    pub fn or_else(&self, s2: &Stream<A>) -> Stream<A>
+    where
+        A: Clone,
+    {
+        self.merge(s2, |lhs: &A, _rhs: &A| lhs.clone())
     }
 
-    pub fn merge<FN:IsLambda2<A,A,A>+Send+Sync+'static>(&self, s2: &Stream<A>, mut f: FN) -> Stream<A> where A: Clone {
+    pub fn merge<FN: IsLambda2<A, A, A> + Send + Sync + 'static>(
+        &self,
+        s2: &Stream<A>,
+        mut f: FN,
+    ) -> Stream<A>
+    where
+        A: Clone,
+    {
         let self_ = self.clone();
         let s2 = s2.clone();
         let s2_node = s2.box_clone();
         let s2_dep = s2.to_dep();
         let sodium_ctx = self.sodium_ctx();
-        Stream::_new(
-            &sodium_ctx,
-            |s: StreamWeakForwardRef<A>| {
-                let f_deps = lambda2_deps(&f);
-                let node = Node::new(
-                    &sodium_ctx,
-                    "Stream::merge",
-                    move || {
-                        self_.with_firing_op(|firing1_op: &mut Option<A>| {
-                            s2.with_firing_op(|firing2_op: &mut Option<A>| {
-                                if let Some(ref firing1) = firing1_op {
-                                    if let Some(ref firing2) = firing2_op {
-                                        s.unwrap()._send(f.call(firing1, firing2));
-                                    } else {
-                                        s.unwrap()._send(firing1.clone());
-                                    }
-                                } else if let Some(ref firing2) = firing2_op {
-                                    s.unwrap()._send(firing2.clone());
+        Stream::_new(&sodium_ctx, |s: StreamWeakForwardRef<A>| {
+            let f_deps = lambda2_deps(&f);
+            let node = Node::new(
+                &sodium_ctx,
+                "Stream::merge",
+                move || {
+                    self_.with_firing_op(|firing1_op: &mut Option<A>| {
+                        s2.with_firing_op(|firing2_op: &mut Option<A>| {
+                            if let Some(ref firing1) = firing1_op {
+                                if let Some(ref firing2) = firing2_op {
+                                    s.unwrap()._send(f.call(firing1, firing2));
+                                } else {
+                                    s.unwrap()._send(firing1.clone());
                                 }
-                            })
+                            } else if let Some(ref firing2) = firing2_op {
+                                s.unwrap()._send(firing2.clone());
+                            }
                         })
-                    },
-                    vec![self.box_clone(), s2_node]
-                );
-                IsNode::add_update_dependencies(&node, f_deps);
-                IsNode::add_update_dependencies(&node, vec![self.to_dep(), s2_dep]);
-                node
-            }
-        )
-    }
-
-    pub fn hold(&self, a: A) -> Cell<A> where A: Clone {
-        let sodium_ctx = self.sodium_ctx();
-        sodium_ctx.transaction(|| {
-            Cell::_new(&sodium_ctx, self.clone(), Lazy::of_value(a))
+                    })
+                },
+                vec![self.box_clone(), s2_node],
+            );
+            IsNode::add_update_dependencies(&node, f_deps);
+            IsNode::add_update_dependencies(&node, vec![self.to_dep(), s2_dep]);
+            node
         })
     }
 
-    pub fn hold_lazy(&self, a: Lazy<A>) -> Cell<A> where A: Clone {
+    pub fn hold(&self, a: A) -> Cell<A>
+    where
+        A: Clone,
+    {
         let sodium_ctx = self.sodium_ctx();
-        sodium_ctx.transaction(|| {
-            Cell::_new(&sodium_ctx, self.clone(), a)
-        })
+        sodium_ctx.transaction(|| Cell::_new(&sodium_ctx, self.clone(), Lazy::of_value(a)))
     }
 
-    pub fn collect_lazy<B,S,F>(&self, init_state: Lazy<S>, f: F) -> Stream<B>
-        where B: Send + Clone + 'static,
-              S: Send + Clone + 'static,
-              F: IsLambda2<A,S,(B,S)> + Send + Sync + 'static
+    pub fn hold_lazy(&self, a: Lazy<A>) -> Cell<A>
+    where
+        A: Clone,
+    {
+        let sodium_ctx = self.sodium_ctx();
+        sodium_ctx.transaction(|| Cell::_new(&sodium_ctx, self.clone(), a))
+    }
+
+    pub fn collect_lazy<B, S, F>(&self, init_state: Lazy<S>, f: F) -> Stream<B>
+    where
+        B: Send + Clone + 'static,
+        S: Send + Clone + 'static,
+        F: IsLambda2<A, S, (B, S)> + Send + Sync + 'static,
     {
         let sodium_ctx = self.sodium_ctx();
         sodium_ctx.transaction(|| {
@@ -343,16 +355,17 @@ impl<A:Send+'static> Stream<A> {
             let es = StreamLoop::new(&sodium_ctx);
             let s = es.stream().hold_lazy(init_state);
             let ebs = ea.snapshot(&s, f);
-            let eb = ebs.map(|(ref a,ref _b):&(B,S)| a.clone());
-            let es_out = ebs.map(|(ref _a,ref b):&(B,S)| b.clone());
+            let eb = ebs.map(|(ref a, ref _b): &(B, S)| a.clone());
+            let es_out = ebs.map(|(ref _a, ref b): &(B, S)| b.clone());
             es.loop_(&es_out);
             eb
         })
     }
 
-    pub fn accum_lazy<S,F>(&self, init_state: Lazy<S>, f: F) -> Cell<S>
-        where S: Send + Clone + 'static,
-              F: IsLambda2<A,S,S> + Send + Sync + 'static
+    pub fn accum_lazy<S, F>(&self, init_state: Lazy<S>, f: F) -> Cell<S>
+    where
+        S: Send + Clone + 'static,
+        F: IsLambda2<A, S, S> + Send + Sync + 'static,
     {
         let sodium_ctx = self.sodium_ctx();
         let sodium_ctx = &sodium_ctx;
@@ -365,14 +378,17 @@ impl<A:Send+'static> Stream<A> {
         })
     }
 
-    pub fn defer(&self) -> Stream<A> where A: Clone {
+    pub fn defer(&self) -> Stream<A>
+    where
+        A: Clone,
+    {
         let sodium_ctx = self.sodium_ctx();
         sodium_ctx.transaction(|| {
             let ss = StreamSink::new(&sodium_ctx);
             let s = ss.stream();
             let sodium_ctx = sodium_ctx.clone();
             let ss = StreamSink::downgrade(&ss);
-            let listener = self.listen_weak(move |a:&A| {
+            let listener = self.listen_weak(move |a: &A| {
                 let ss = ss.upgrade().unwrap();
                 let a = a.clone();
                 sodium_ctx.post(move || ss.send(a.clone()))
@@ -382,70 +398,73 @@ impl<A:Send+'static> Stream<A> {
         })
     }
 
-    pub fn once(&self) -> Stream<A> where A: Clone {
+    pub fn once(&self) -> Stream<A>
+    where
+        A: Clone,
+    {
         let self_ = self.clone();
         let sodium_ctx = self.sodium_ctx();
-        Stream::_new(
-            &sodium_ctx,
-            |s: StreamWeakForwardRef<A>| {
-                let sodium_ctx = sodium_ctx.clone();
-                let sodium_ctx2 = sodium_ctx.clone();
-                let node = Node::new(
-                    &sodium_ctx2,
-                    "Stream::once",
-                    move || {
-                        self_.with_firing_op(|firing_op: &mut Option<A>| {
-                            if let Some(ref firing) = firing_op {
-                                let s = s.unwrap();
-                                s._send(firing.clone());
-                                let node = s.box_clone();
-                                sodium_ctx.post(move || {
-                                    let deps;
-                                    {
-                                        let dependencies = node.data().dependencies.read().unwrap();
-                                        deps = box_clone_vec_is_node(&(*dependencies));
-                                    }
-                                    for dep in deps {
-                                        IsNode::remove_dependency(node.node(), dep.node());
-                                    }
-                                });
-                            }
-                        })
-                    },
-                    vec![self.box_clone()]
-                );
-                IsNode::add_update_dependencies(&node, vec![self.to_dep()]);
-                node
-            }
-        )
+        Stream::_new(&sodium_ctx, |s: StreamWeakForwardRef<A>| {
+            let sodium_ctx = sodium_ctx.clone();
+            let sodium_ctx2 = sodium_ctx.clone();
+            let node = Node::new(
+                &sodium_ctx2,
+                "Stream::once",
+                move || {
+                    self_.with_firing_op(|firing_op: &mut Option<A>| {
+                        if let Some(ref firing) = firing_op {
+                            let s = s.unwrap();
+                            s._send(firing.clone());
+                            let node = s.box_clone();
+                            sodium_ctx.post(move || {
+                                let deps;
+                                {
+                                    let dependencies = node.data().dependencies.read().unwrap();
+                                    deps = box_clone_vec_is_node(&(*dependencies));
+                                }
+                                for dep in deps {
+                                    IsNode::remove_dependency(node.node(), dep.node());
+                                }
+                            });
+                        }
+                    })
+                },
+                vec![self.box_clone()],
+            );
+            IsNode::add_update_dependencies(&node, vec![self.to_dep()]);
+            node
+        })
     }
 
-    pub fn _listen<K:IsLambda1<A,()>+Send+Sync+'static>(&self, mut k: K, weak: bool) -> Listener {
+    pub fn _listen<K: IsLambda1<A, ()> + Send + Sync + 'static>(
+        &self,
+        mut k: K,
+        weak: bool,
+    ) -> Listener {
         let self_ = self.clone();
         let f_deps = lambda1_deps(&k);
-        let node =
-            Node::new(
-                &self.sodium_ctx(),
-                "Stream::listen",
-                move || {
-                    self_.with_data(|data: &mut StreamData<A>| {
-                        for firing in &data.firing_op {
-                            k.call(firing)
-                        }
-                    });
-                },
-                vec![self.box_clone()]
-            );
+        let node = Node::new(
+            &self.sodium_ctx(),
+            "Stream::listen",
+            move || {
+                self_.with_data(|data: &mut StreamData<A>| {
+                    for firing in &data.firing_op {
+                        k.call(firing)
+                    }
+                });
+            },
+            vec![self.box_clone()],
+        );
         IsNode::add_update_dependencies(&node, vec![self.to_dep()]);
         IsNode::add_update_dependencies(&node, f_deps);
         Listener::new(&self.sodium_ctx(), weak, node)
     }
 
-    pub fn listen_weak<K:IsLambda1<A,()>+Send+Sync+'static>(&self, k: K) -> Listener {
+    pub fn listen_weak<K: IsLambda1<A, ()> + Send + Sync + 'static>(&self, k: K) -> Listener {
         self._listen(k, true)
     }
 
-    pub fn listen<K:IsLambda1<A,()>+Send+Sync+'static>(&self, k: K) -> Listener {
+    pub fn listen<K: IsLambda1<A, ()> + Send + Sync + 'static>(&self, k: K) -> Listener {
         self._listen(k, false)
     }
 
@@ -491,7 +510,7 @@ impl<A:Send+'static> Stream<A> {
     pub fn downgrade(this: &Self) -> WeakStream<A> {
         WeakStream {
             data: Arc::downgrade(&this.data),
-            node: Node::downgrade2(&this.node)
+            node: Node::downgrade2(&this.node),
         }
     }
 }

--- a/src/impl_/stream_sink.rs
+++ b/src/impl_/stream_sink.rs
@@ -1,40 +1,43 @@
 use crate::impl_::node::IsNode;
-use crate::impl_::stream::Stream;
-use crate::impl_::stream::WeakStream;
 use crate::impl_::sodium_ctx::SodiumCtx;
 use crate::impl_::sodium_ctx::SodiumCtxData;
+use crate::impl_::stream::Stream;
+use crate::impl_::stream::WeakStream;
 
 pub struct StreamSink<A> {
     stream: Stream<A>,
-    sodium_ctx: SodiumCtx
+    sodium_ctx: SodiumCtx,
 }
 
 pub struct WeakStreamSink<A> {
     stream: WeakStream<A>,
-    sodium_ctx: SodiumCtx
+    sodium_ctx: SodiumCtx,
 }
 
 impl<A> Clone for StreamSink<A> {
     fn clone(&self) -> Self {
         StreamSink {
             stream: self.stream.clone(),
-            sodium_ctx: self.sodium_ctx.clone()
+            sodium_ctx: self.sodium_ctx.clone(),
         }
     }
 }
 
-impl<A:Send+'static> StreamSink<A> {
+impl<A: Send + 'static> StreamSink<A> {
     pub fn new(sodium_ctx: &SodiumCtx) -> StreamSink<A> {
         StreamSink {
             stream: Stream::new(sodium_ctx),
-            sodium_ctx: sodium_ctx.clone()
+            sodium_ctx: sodium_ctx.clone(),
         }
     }
 
-    pub fn new_with_coalescer<COALESCER:FnMut(&A,&A)->A+Send+'static>(sodium_ctx: &SodiumCtx, coalescer: COALESCER) -> StreamSink<A> {
+    pub fn new_with_coalescer<COALESCER: FnMut(&A, &A) -> A + Send + 'static>(
+        sodium_ctx: &SodiumCtx,
+        coalescer: COALESCER,
+    ) -> StreamSink<A> {
         StreamSink {
             stream: Stream::_new_with_coalescer(sodium_ctx, coalescer),
-            sodium_ctx: sodium_ctx.clone()
+            sodium_ctx: sodium_ctx.clone(),
         }
     }
 
@@ -59,7 +62,7 @@ impl<A:Send+'static> StreamSink<A> {
     pub fn downgrade(this: &Self) -> WeakStreamSink<A> {
         WeakStreamSink {
             stream: Stream::downgrade(&this.stream),
-            sodium_ctx: this.sodium_ctx.clone()
+            sodium_ctx: this.sodium_ctx.clone(),
         }
     }
 }
@@ -67,6 +70,8 @@ impl<A:Send+'static> StreamSink<A> {
 impl<A> WeakStreamSink<A> {
     pub fn upgrade(&self) -> Option<StreamSink<A>> {
         let sodium_ctx = self.sodium_ctx.clone();
-        self.stream.upgrade().map(|stream: Stream<A>| StreamSink { stream, sodium_ctx })
+        self.stream
+            .upgrade()
+            .map(|stream: Stream<A>| StreamSink { stream, sodium_ctx })
     }
 }

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,7 +1,7 @@
 use crate::impl_::listener::Listener as ListenerImpl;
 
 pub struct Listener {
-    pub impl_: ListenerImpl
+    pub impl_: ListenerImpl,
 }
 
 impl Listener {

--- a/src/operational.rs
+++ b/src/operational.rs
@@ -4,16 +4,21 @@ use crate::Stream;
 pub struct Operational {}
 
 impl Operational {
-
-    pub fn updates<A:Clone+Send+'static>(ca: &Cell<A>) -> Stream<A> {
-        Stream { impl_: ca.impl_.updates() }
+    pub fn updates<A: Clone + Send + 'static>(ca: &Cell<A>) -> Stream<A> {
+        Stream {
+            impl_: ca.impl_.updates(),
+        }
     }
 
-    pub fn value<A:Clone+Send+'static>(ca: &Cell<A>) -> Stream<A> {
-        Stream { impl_: ca.impl_.value() }
+    pub fn value<A: Clone + Send + 'static>(ca: &Cell<A>) -> Stream<A> {
+        Stream {
+            impl_: ca.impl_.value(),
+        }
     }
 
-    pub fn defer<A:Clone+Send+'static>(sa: &Stream<A>) -> Stream<A> {
-        Stream { impl_: sa.impl_.defer() }
+    pub fn defer<A: Clone + Send + 'static>(sa: &Stream<A>) -> Stream<A> {
+        Stream {
+            impl_: sa.impl_.defer(),
+        }
     }
 }

--- a/src/sodium_ctx.rs
+++ b/src/sodium_ctx.rs
@@ -1,14 +1,14 @@
-use crate::Cell;
-use crate::CellSink;
-use crate::CellLoop;
-use crate::Stream;
-use crate::StreamSink;
-use crate::StreamLoop;
 use crate::impl_::sodium_ctx::SodiumCtx as SodiumCtxImpl;
+use crate::Cell;
+use crate::CellLoop;
+use crate::CellSink;
+use crate::Stream;
+use crate::StreamLoop;
+use crate::StreamSink;
 
 #[derive(Clone)]
 pub struct SodiumCtx {
-    pub impl_: SodiumCtxImpl
+    pub impl_: SodiumCtxImpl,
 }
 
 impl Default for SodiumCtx {
@@ -19,38 +19,46 @@ impl Default for SodiumCtx {
 
 impl SodiumCtx {
     pub fn new() -> SodiumCtx {
-        SodiumCtx { impl_: SodiumCtxImpl::new() }
+        SodiumCtx {
+            impl_: SodiumCtxImpl::new(),
+        }
     }
 
-    pub fn new_cell<A:Clone+Send+'static>(&self, a: A) -> Cell<A> {
+    pub fn new_cell<A: Clone + Send + 'static>(&self, a: A) -> Cell<A> {
         Cell::new(self, a)
     }
 
-    pub fn new_stream<A:Clone+Send+'static>(&self) -> Stream<A> {
+    pub fn new_stream<A: Clone + Send + 'static>(&self) -> Stream<A> {
         Stream::new(self)
     }
 
-    pub fn new_cell_sink<A:Clone+Send+'static>(&self, a: A) -> CellSink<A> {
+    pub fn new_cell_sink<A: Clone + Send + 'static>(&self, a: A) -> CellSink<A> {
         CellSink::new(self, a)
     }
 
-    pub fn new_stream_sink<A:Clone+Send+'static>(&self) -> StreamSink<A> {
+    pub fn new_stream_sink<A: Clone + Send + 'static>(&self) -> StreamSink<A> {
         StreamSink::new(self)
     }
 
-    pub fn new_cell_loop<A:Clone+Send+'static>(&self) -> CellLoop<A> {
+    pub fn new_cell_loop<A: Clone + Send + 'static>(&self) -> CellLoop<A> {
         CellLoop::new(self)
     }
 
-    pub fn new_stream_loop<A:Clone+Send+'static>(&self) -> StreamLoop<A> {
+    pub fn new_stream_loop<A: Clone + Send + 'static>(&self) -> StreamLoop<A> {
         StreamLoop::new(self)
     }
 
-    pub fn new_stream_sink_with_coalescer<A:Clone+Send+'static,COALESCER:FnMut(&A,&A)->A+Send+'static>(&self, coalescer: COALESCER) -> StreamSink<A> {
+    pub fn new_stream_sink_with_coalescer<
+        A: Clone + Send + 'static,
+        COALESCER: FnMut(&A, &A) -> A + Send + 'static,
+    >(
+        &self,
+        coalescer: COALESCER,
+    ) -> StreamSink<A> {
         StreamSink::new_with_coalescer(self, coalescer)
     }
 
-    pub fn transaction<R,K:FnOnce()->R>(&self, k: K) -> R {
+    pub fn transaction<R, K: FnOnce() -> R>(&self, k: K) -> R {
         self.impl_.transaction(k)
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,36 +1,37 @@
 use crate::cell::Cell;
 use crate::impl_::dep::Dep;
-use crate::impl_::stream::Stream as StreamImpl;
 use crate::impl_::lambda::IsLambda1;
 use crate::impl_::lambda::IsLambda2;
 use crate::impl_::lambda::IsLambda3;
 use crate::impl_::lambda::{lambda1, lambda2};
-use crate::Lazy;
+use crate::impl_::stream::Stream as StreamImpl;
 use crate::listener::Listener;
 use crate::sodium_ctx::SodiumCtx;
+use crate::Lazy;
 
 pub struct Stream<A> {
-    pub impl_: StreamImpl<A>
+    pub impl_: StreamImpl<A>,
 }
 
 impl<A> Clone for Stream<A> {
     fn clone(&self) -> Self {
         Stream {
-            impl_: self.impl_.clone()
+            impl_: self.impl_.clone(),
         }
     }
 }
 
-impl<A:Clone+Send+'static> Stream<Option<A>> {
+impl<A: Clone + Send + 'static> Stream<Option<A>> {
     pub fn filter_option(&self) -> Stream<A> {
-        self.filter(|a: &Option<A>| a.is_some()).map(|a: &Option<A>| a.clone().unwrap())
+        self.filter(|a: &Option<A>| a.is_some())
+            .map(|a: &Option<A>| a.clone().unwrap())
     }
 }
 
-impl<A:Clone+Send+'static> Stream<A> {
+impl<A: Clone + Send + 'static> Stream<A> {
     pub fn new(sodium_ctx: &SodiumCtx) -> Stream<A> {
         Stream {
-            impl_: StreamImpl::new(&sodium_ctx.impl_)
+            impl_: StreamImpl::new(&sodium_ctx.impl_),
         }
     }
 
@@ -39,15 +40,35 @@ impl<A:Clone+Send+'static> Stream<A> {
         self.impl_.to_dep()
     }
 
-    pub fn snapshot<B:Clone+Send+'static,C:Clone+Send+'static,FN:IsLambda2<A,B,C>+Send+Sync+'static>(&self, cb: &Cell<B>, f: FN) -> Stream<C> {
-        Stream { impl_: self.impl_.snapshot(&cb.impl_, f) }
+    pub fn snapshot<
+        B: Clone + Send + 'static,
+        C: Clone + Send + 'static,
+        FN: IsLambda2<A, B, C> + Send + Sync + 'static,
+    >(
+        &self,
+        cb: &Cell<B>,
+        f: FN,
+    ) -> Stream<C> {
+        Stream {
+            impl_: self.impl_.snapshot(&cb.impl_, f),
+        }
     }
 
-    pub fn snapshot1<B:Send+Clone+'static>(&self, cb: &Cell<B>) -> Stream<B> {
+    pub fn snapshot1<B: Send + Clone + 'static>(&self, cb: &Cell<B>) -> Stream<B> {
         self.snapshot(cb, |_a: &A, b: &B| b.clone())
     }
 
-    pub fn snapshot3<B:Send+Clone+'static,C:Send+Clone+'static,D:Send+Clone+'static,FN:IsLambda3<A,B,C,D>+Send+Sync+'static>(&self, cb: &Cell<B>, cc: &Cell<C>, mut f: FN) -> Stream<D> {
+    pub fn snapshot3<
+        B: Send + Clone + 'static,
+        C: Send + Clone + 'static,
+        D: Send + Clone + 'static,
+        FN: IsLambda3<A, B, C, D> + Send + Sync + 'static,
+    >(
+        &self,
+        cb: &Cell<B>,
+        cc: &Cell<C>,
+        mut f: FN,
+    ) -> Stream<D> {
         let deps: Vec<Dep>;
         if let Some(deps2) = f.deps_op() {
             deps = deps2.clone();
@@ -55,35 +76,58 @@ impl<A:Clone+Send+'static> Stream<A> {
             deps = Vec::new();
         }
         let cc = cc.clone();
-        self.snapshot(cb, lambda2(move |a: &A, b: &B| f.call(a, b, &cc.sample()), deps))
+        self.snapshot(
+            cb,
+            lambda2(move |a: &A, b: &B| f.call(a, b, &cc.sample()), deps),
+        )
     }
 
-    pub fn map<B:Send+Clone+'static,FN:IsLambda1<A,B>+Send+Sync+'static>(&self, f: FN) -> Stream<B> {
-        Stream { impl_: self.impl_.map(f) }
+    pub fn map<B: Send + Clone + 'static, FN: IsLambda1<A, B> + Send + Sync + 'static>(
+        &self,
+        f: FN,
+    ) -> Stream<B> {
+        Stream {
+            impl_: self.impl_.map(f),
+        }
     }
 
-    pub fn map_to<B:Send+Sync+Clone+'static>(&self, b: B) -> Stream<B> {
-        self.map(move |_:&A| b.clone())
+    pub fn map_to<B: Send + Sync + Clone + 'static>(&self, b: B) -> Stream<B> {
+        self.map(move |_: &A| b.clone())
     }
 
-    pub fn filter<PRED:IsLambda1<A,bool>+Send+Sync+'static>(&self, pred: PRED) -> Stream<A> {
-        Stream { impl_: self.impl_.filter(pred) }
+    pub fn filter<PRED: IsLambda1<A, bool> + Send + Sync + 'static>(
+        &self,
+        pred: PRED,
+    ) -> Stream<A> {
+        Stream {
+            impl_: self.impl_.filter(pred),
+        }
     }
 
     pub fn or_else(&self, s2: &Stream<A>) -> Stream<A> {
-        self.merge(s2, |lhs:&A, _rhs:&A| lhs.clone())
+        self.merge(s2, |lhs: &A, _rhs: &A| lhs.clone())
     }
 
-    pub fn merge<FN:IsLambda2<A,A,A>+Send+Sync+'static>(&self, s2: &Stream<A>, f: FN) -> Stream<A> {
-        Stream { impl_: self.impl_.merge(&s2.impl_, f) }
+    pub fn merge<FN: IsLambda2<A, A, A> + Send + Sync + 'static>(
+        &self,
+        s2: &Stream<A>,
+        f: FN,
+    ) -> Stream<A> {
+        Stream {
+            impl_: self.impl_.merge(&s2.impl_, f),
+        }
     }
 
     pub fn hold(&self, a: A) -> Cell<A> {
-        Cell { impl_: self.impl_.hold(a) }
+        Cell {
+            impl_: self.impl_.hold(a),
+        }
     }
 
     pub fn hold_lazy(&self, a: Lazy<A>) -> Cell<A> {
-        Cell { impl_: self.impl_.hold_lazy(a) }
+        Cell {
+            impl_: self.impl_.hold_lazy(a),
+        }
     }
 
     pub fn gate(&self, cpred: &Cell<bool>) -> Stream<A> {
@@ -93,44 +137,58 @@ impl<A:Clone+Send+'static> Stream<A> {
     }
 
     pub fn once(&self) -> Stream<A> {
-        Stream { impl_: self.impl_.once() }
+        Stream {
+            impl_: self.impl_.once(),
+        }
     }
 
-    pub fn collect<B,S,F>(&self, init_state: S, f: F) -> Stream<B>
-        where B: Send + Clone + 'static,
-              S: Send + Clone + 'static,
-              F: IsLambda2<A,S,(B,S)> + Send + Sync + 'static
+    pub fn collect<B, S, F>(&self, init_state: S, f: F) -> Stream<B>
+    where
+        B: Send + Clone + 'static,
+        S: Send + Clone + 'static,
+        F: IsLambda2<A, S, (B, S)> + Send + Sync + 'static,
     {
         self.collect_lazy(Lazy::new(move || init_state.clone()), f)
     }
 
-    pub fn collect_lazy<B,S,F>(&self, init_state: Lazy<S>, f: F) -> Stream<B>
-        where B: Send + Clone + 'static,
-              S: Send + Clone + 'static,
-              F: IsLambda2<A,S,(B,S)> + Send + Sync + 'static
+    pub fn collect_lazy<B, S, F>(&self, init_state: Lazy<S>, f: F) -> Stream<B>
+    where
+        B: Send + Clone + 'static,
+        S: Send + Clone + 'static,
+        F: IsLambda2<A, S, (B, S)> + Send + Sync + 'static,
     {
-        Stream { impl_: self.impl_.collect_lazy(init_state, f) }
+        Stream {
+            impl_: self.impl_.collect_lazy(init_state, f),
+        }
     }
 
-    pub fn accum<S,F>(&self, init_state: S, f: F) -> Cell<S>
-        where S: Send + Clone + 'static,
-              F: IsLambda2<A,S,S> + Send + Sync + 'static
+    pub fn accum<S, F>(&self, init_state: S, f: F) -> Cell<S>
+    where
+        S: Send + Clone + 'static,
+        F: IsLambda2<A, S, S> + Send + Sync + 'static,
     {
         self.accum_lazy(Lazy::new(move || init_state.clone()), f)
     }
 
-    pub fn accum_lazy<S,F>(&self, init_state: Lazy<S>, f: F) -> Cell<S>
-        where S: Send + Clone + 'static,
-              F: IsLambda2<A,S,S> + Send + Sync + 'static
+    pub fn accum_lazy<S, F>(&self, init_state: Lazy<S>, f: F) -> Cell<S>
+    where
+        S: Send + Clone + 'static,
+        F: IsLambda2<A, S, S> + Send + Sync + 'static,
     {
-        Cell { impl_: self.impl_.accum_lazy(init_state, f) }
+        Cell {
+            impl_: self.impl_.accum_lazy(init_state, f),
+        }
     }
 
-    pub fn listen_weak<K:IsLambda1<A,()>+Send+Sync+'static>(&self, k: K) -> Listener {
-        Listener { impl_: self.impl_.listen_weak(k) }
+    pub fn listen_weak<K: IsLambda1<A, ()> + Send + Sync + 'static>(&self, k: K) -> Listener {
+        Listener {
+            impl_: self.impl_.listen_weak(k),
+        }
     }
 
-    pub fn listen<K:IsLambda1<A,()>+Send+Sync+'static>(&self, k: K) -> Listener {
-        Listener { impl_: self.impl_.listen(k) }
+    pub fn listen<K: IsLambda1<A, ()> + Send + Sync + 'static>(&self, k: K) -> Listener {
+        Listener {
+            impl_: self.impl_.listen(k),
+        }
     }
 }

--- a/src/stream_loop.rs
+++ b/src/stream_loop.rs
@@ -3,17 +3,20 @@ use crate::SodiumCtx;
 use crate::Stream;
 
 pub struct StreamLoop<A> {
-    pub impl_: StreamLoopImpl<A>
+    pub impl_: StreamLoopImpl<A>,
 }
 
-impl<A:Send+Clone+'static> StreamLoop<A> {
-
+impl<A: Send + Clone + 'static> StreamLoop<A> {
     pub fn new(sodium_ctx: &SodiumCtx) -> StreamLoop<A> {
-        StreamLoop { impl_: StreamLoopImpl::new(&sodium_ctx.impl_) }
+        StreamLoop {
+            impl_: StreamLoopImpl::new(&sodium_ctx.impl_),
+        }
     }
 
     pub fn stream(&self) -> Stream<A> {
-        Stream { impl_: self.impl_.stream() }
+        Stream {
+            impl_: self.impl_.stream(),
+        }
     }
 
     pub fn loop_(&self, sa: &Stream<A>) {

--- a/src/stream_sink.rs
+++ b/src/stream_sink.rs
@@ -3,28 +3,37 @@ use crate::sodium_ctx::SodiumCtx;
 use crate::stream::Stream;
 
 pub struct StreamSink<A> {
-    pub impl_: StreamSinkImpl<A>
+    pub impl_: StreamSinkImpl<A>,
 }
 
 impl<A> Clone for StreamSink<A> {
     fn clone(&self) -> Self {
         StreamSink {
-            impl_: self.impl_.clone()
+            impl_: self.impl_.clone(),
         }
     }
 }
 
-impl<A:Clone+Send+'static> StreamSink<A> {
+impl<A: Clone + Send + 'static> StreamSink<A> {
     pub fn new(sodium_ctx: &SodiumCtx) -> StreamSink<A> {
-        StreamSink { impl_: StreamSinkImpl::new(&sodium_ctx.impl_) }
+        StreamSink {
+            impl_: StreamSinkImpl::new(&sodium_ctx.impl_),
+        }
     }
 
-    pub fn new_with_coalescer<COALESCER:FnMut(&A,&A)->A+Send+'static>(sodium_ctx: &SodiumCtx, coalescer: COALESCER) -> StreamSink<A> {
-        StreamSink { impl_: StreamSinkImpl::new_with_coalescer(&sodium_ctx.impl_, coalescer) }
+    pub fn new_with_coalescer<COALESCER: FnMut(&A, &A) -> A + Send + 'static>(
+        sodium_ctx: &SodiumCtx,
+        coalescer: COALESCER,
+    ) -> StreamSink<A> {
+        StreamSink {
+            impl_: StreamSinkImpl::new_with_coalescer(&sodium_ctx.impl_, coalescer),
+        }
     }
 
     pub fn stream(&self) -> Stream<A> {
-        Stream { impl_: self.impl_.stream() }
+        Stream {
+            impl_: self.impl_.stream(),
+        }
     }
 
     pub fn send(&self, a: A) {

--- a/src/tests/mem_test.rs
+++ b/src/tests/mem_test.rs
@@ -24,7 +24,7 @@ fn mem() {
         let s = sodium_ctx.new_stream::<i32>();
         let s2 = s.map_to(5);
         let s3 = s2.map_to(3);
-        let l = s3.listen_weak(|_:&i32| {});
+        let l = s3.listen_weak(|_: &i32| {});
         l.unlisten();
     }
     sodium_ctx.impl_.collect_cycles();
@@ -45,7 +45,7 @@ fn map_s_mem() {
         let ss1: StreamSink<i32> = sodium_ctx.new_stream_sink();
         let s1 = ss1.stream();
         let _s2 = s1.map_to(5);
-        let l = _s2.listen_weak(|_:&u32| {});
+        let l = _s2.listen_weak(|_: &u32| {});
         println!("l: {:?}", l.impl_);
         l.unlisten();
     }
@@ -66,7 +66,7 @@ fn map_c_mem() {
     {
         let cs1: CellSink<i32> = sodium_ctx.new_cell_sink(3);
         let c1 = cs1.cell();
-        let _c2 = c1.map(|a:&i32| a + 5);
+        let _c2 = c1.map(|a: &i32| a + 5);
         //let l = _c2.listen_weak(|_:&i32| {});
         //l.unlisten();
     }

--- a/src/tests/node_test.rs
+++ b/src/tests/node_test.rs
@@ -1,6 +1,5 @@
-
+use crate::impl_::node::{IsNode, Node};
 use crate::impl_::sodium_ctx::SodiumCtx;
-use crate::impl_::node::{IsNode,Node};
 use crate::tests::init;
 
 #[test]
@@ -8,27 +7,9 @@ fn node_mem_1() {
     init();
     let sodium_ctx = SodiumCtx::new();
     {
-        let node1 =
-            Node::new(
-                &sodium_ctx,
-                "node1",
-                || {},
-                vec![]
-            );
-        let node2 =
-            Node::new(
-                &sodium_ctx,
-                "node2",
-                || {},
-                vec![node1.box_clone()]
-            );
-        let node3 =
-            Node::new(
-                &sodium_ctx,
-                "node3",
-                || {},
-                vec![node2.box_clone()]
-            );
+        let node1 = Node::new(&sodium_ctx, "node1", || {}, vec![]);
+        let node2 = Node::new(&sodium_ctx, "node2", || {}, vec![node1.box_clone()]);
+        let node3 = Node::new(&sodium_ctx, "node3", || {}, vec![node2.box_clone()]);
         IsNode::add_dependency(&node1, node3);
     }
     assert_memory_freed(&sodium_ctx);
@@ -50,60 +31,17 @@ fn node_mem_2() {
             \ /
              5
         */
-        let node0 =
-            Node::new(
-                &sodium_ctx,
-                "node0",
-                || {},
-                vec![]
-            );
-        let node1 =
-            Node::new(
-                &sodium_ctx,
-                "node1",
-                || {},
-                vec![node0.box_clone()]
-            );
-        let node2 =
-            Node::new(
-                &sodium_ctx,
-                "node2",
-                || {},
-                vec![node1.box_clone()]
-            );
-        let node3 =
-            Node::new(
-                &sodium_ctx,
-                "node3",
-                || {},
-                vec![node2.box_clone()]
-            );
-        IsNode::add_dependency(&node0,node3);
-        let node4 =
-            Node::new(
-                &sodium_ctx,
-                "node4",
-                || {},
-                vec![node2.box_clone()]
-            );
-        let node5 =
-            Node::new(
-                &sodium_ctx,
-                "node5",
-                || {},
-                vec![node4.box_clone()]
-            );
-        let node6 =
-            Node::new(
-                &sodium_ctx,
-                "node6",
-                || {},
-                vec![node5.box_clone()]
-            );
+        let node0 = Node::new(&sodium_ctx, "node0", || {}, vec![]);
+        let node1 = Node::new(&sodium_ctx, "node1", || {}, vec![node0.box_clone()]);
+        let node2 = Node::new(&sodium_ctx, "node2", || {}, vec![node1.box_clone()]);
+        let node3 = Node::new(&sodium_ctx, "node3", || {}, vec![node2.box_clone()]);
+        IsNode::add_dependency(&node0, node3);
+        let node4 = Node::new(&sodium_ctx, "node4", || {}, vec![node2.box_clone()]);
+        let node5 = Node::new(&sodium_ctx, "node5", || {}, vec![node4.box_clone()]);
+        let node6 = Node::new(&sodium_ctx, "node6", || {}, vec![node5.box_clone()]);
         IsNode::add_dependency(&node2, node6);
     }
     assert_memory_freed(&sodium_ctx);
-
 }
 
 pub fn assert_memory_freed(sodium_ctx: &SodiumCtx) {


### PR DESCRIPTION
Reformats the code using rustfmt.

Also adds a formatting check to the CI workflow.

In addition, now that all Clippy warnings have been taken care of in my previous pull request, I change the clippy check in CI to fail on warnings.

Fixes #52