### PR TITLE
Add API documentation comments

### DIFF
--- a/src/cell.rs
+++ b/src/cell.rs
@@ -11,6 +11,12 @@ use crate::sodium_ctx::SodiumCtx;
 use crate::stream::Stream;
 use crate::Dep;
 
+/// Represents a value of type `A` that changes over time.
+///
+/// In other Functional Reactive Programming (FRP) systems this is
+/// also called a _behavior_, _property_, or a _signal_. A `Cell`
+/// should be used for modeling any pieces of mutable state in an FRP
+/// application.
 pub struct Cell<A> {
     pub impl_: CellImpl<A>,
 }

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -30,37 +30,84 @@ impl<A> Clone for Cell<A> {
 }
 
 impl<A: Clone + Send + 'static> Cell<A> {
+    /// Create a `Cell` with a constant value.
     pub fn new(sodium_ctx: &SodiumCtx, value: A) -> Cell<A> {
         Cell {
             impl_: CellImpl::new(&sodium_ctx.impl_, value),
         }
     }
 
+    /// Sample the `Cell`'s current value.
+    ///
+    /// `Cell::sample` may be used in the functions passed to
+    /// primitives that apply them to [`Stream`]s, including
+    /// [`Stream::map`], [`Stream::snapshot`], [`Stream::filter`], and
+    /// [`Stream::merge`].
+    ///
+    /// When called within a function passed to [`Stream::map`] using
+    /// `sample` is equivalent to [snapshotting][Stream::snapshot]
+    /// this `Cell` with that [`Stream`].
     pub fn sample(&self) -> A {
         self.impl_.sample()
     }
 
+    /// Sample the `Cell`'s current value lazily.
+    ///
+    /// When it is necessary to use `sample` while implementing more
+    /// general abstractions, `sample_lazy` should be preferred in
+    /// case a [`CellLoop`][crate::CellLoop] is passed rather than a
+    /// `Cell`.
+    ///
+    /// See [`Cell::sample`] for more details.
     pub fn sample_lazy(&self) -> Lazy<A> {
         self.impl_.sample_lazy()
     }
 
     // use as dependency to lambda1, lambda2, etc.
+    #[doc(hidden)]
     pub fn to_dep(&self) -> Dep {
         self.impl_.to_dep()
     }
 
+    /// Return a [`Stream`] that gives the updates/steps for a `Cell`.
+    ///
+    /// ## Important
+    ///
+    /// This is an operational primitive, which isn't part of the main
+    /// Sodium API. It breaks the property of non-detectability of
+    /// cell updates/steps. The rule with this primitive is that you
+    /// should only use it in functions that don't allow the caller to
+    /// detect the `Cell` updates.
     pub fn updates(&self) -> Stream<A> {
         Stream {
             impl_: self.impl_.updates(),
         }
     }
 
+    /// Return a [`Stream`] that is guaranteed to fire at least once.
+    ///
+    /// When `value` is called, the returned `Stream` will fire once
+    /// in the current transaction with the current value of this
+    /// `Cell` and thereafter behaves like [`Cell::updates`].
+    ///
+    /// ## Important
+    ///
+    /// This is an operational primitive, which isn't part of the main
+    /// Sodium API. It breaks the property of non-detectability of
+    /// cell updates/steps. The rule with this primitive is that you
+    /// should only use it in functions that don't allow the caller to
+    /// detect the `Cell` updates.
     pub fn value(&self) -> Stream<A> {
         Stream {
             impl_: self.impl_.value(),
         }
     }
 
+    /// Transform the `Cell`s value with the supplied function.
+    ///
+    /// The returned `Cell` always reflects the value produced by the
+    /// function applied to the input `Cell`s value. The given
+    /// function _must_ be referentially transparent.
     pub fn map<B: Clone + Send + 'static, FN: IsLambda1<A, B> + Send + Sync + 'static>(
         &self,
         f: FN,
@@ -70,6 +117,9 @@ impl<A: Clone + Send + 'static> Cell<A> {
         }
     }
 
+    /// Lift a binary function into cells so the returned [`Cell`]
+    /// always reflects the specified function applied to the input
+    /// cells' values.
     pub fn lift2<
         B: Clone + Send + 'static,
         C: Clone + Send + 'static,
@@ -84,6 +134,9 @@ impl<A: Clone + Send + 'static> Cell<A> {
         }
     }
 
+    /// Lift a ternary function into cells so the returned [`Cell`]
+    /// always reflects the specified function applied to the input
+    /// cells' values.
     pub fn lift3<
         B: Clone + Send + 'static,
         C: Clone + Send + 'static,
@@ -100,6 +153,9 @@ impl<A: Clone + Send + 'static> Cell<A> {
         }
     }
 
+    /// Lift a quaternary function into cells so the returned [`Cell`]
+    /// always reflects the specified function applied to the input
+    /// cells' values.
     pub fn lift4<
         B: Clone + Send + 'static,
         C: Clone + Send + 'static,
@@ -118,6 +174,9 @@ impl<A: Clone + Send + 'static> Cell<A> {
         }
     }
 
+    /// Lift a five-argument function into cells so the returned
+    /// [`Cell`] always reflects the specified function applied to the
+    /// input cells' values.
     pub fn lift5<
         B: Clone + Send + 'static,
         C: Clone + Send + 'static,
@@ -140,6 +199,9 @@ impl<A: Clone + Send + 'static> Cell<A> {
         }
     }
 
+    /// Lift a six argument function into cells so the returned
+    /// [`Cell`] always reflects the specified function applied to the
+    /// input cells' values.
     pub fn lift6<
         B: Clone + Send + 'static,
         C: Clone + Send + 'static,
@@ -164,24 +226,36 @@ impl<A: Clone + Send + 'static> Cell<A> {
         }
     }
 
+    /// Unwrap a [`Stream`] in a `Cell` to give a time-varying stream implementation.
     pub fn switch_s(csa: &Cell<Stream<A>>) -> Stream<A> {
         Stream {
             impl_: CellImpl::switch_s(&csa.map(|sa: &Stream<A>| sa.impl_.clone()).impl_),
         }
     }
 
+    /// Unwrap a `Cell` in another `Cell` to give a time-varying cell implementation.
     pub fn switch_c(cca: &Cell<Cell<A>>) -> Cell<A> {
         Cell {
             impl_: CellImpl::switch_c(&cca.map(|ca: &Cell<A>| ca.impl_.clone()).impl_),
         }
     }
 
+    /// A variant of [`listen`][Cell::listen] that will deregister the
+    /// listener automatically if the listener is garbage-collected.
     pub fn listen_weak<K: FnMut(&A) + Send + Sync + 'static>(&self, k: K) -> Listener {
         Listener {
             impl_: self.impl_.listen_weak(k),
         }
     }
 
+    /// Listen for updates to the value of this `Cell`.
+    ///
+    /// This is the observer pattern. The returned [`Listener`] has an
+    /// [`unlisten`][Listener::unlisten] method to cause the listener
+    /// to be removed.
+    ///
+    /// This is an operational mechanism for interfacing between the
+    /// world of I/O and FRP.
     pub fn listen<K: IsLambda1<A, ()> + Send + Sync + 'static>(&self, k: K) -> Listener {
         Listener {
             impl_: self.impl_.listen(k),

--- a/src/cell_loop.rs
+++ b/src/cell_loop.rs
@@ -22,18 +22,33 @@ impl<A> Clone for CellLoop<A> {
 }
 
 impl<A: Send + Clone + 'static> CellLoop<A> {
+    /// Create a new `CellLoop` in the given context.
     pub fn new(sodium_ctx: &SodiumCtx) -> CellLoop<A> {
         CellLoop {
             impl_: CellLoopImpl::new(&sodium_ctx.impl_),
         }
     }
 
+    /// Return a [`Cell`] that is equivalent to this `CellLoop` once it
+    /// has been resolved by calling [`loop_`][CellLoop::loop_].
+    ///
+    /// If a [`Cell`] created by `CellLoop` may be passed to an
+    /// abstraction that uses [`Cell::sample`], then
+    /// [`Cell::sample_lazy`] should be used instead.
     pub fn cell(&self) -> Cell<A> {
         Cell {
             impl_: self.impl_.cell(),
         }
     }
 
+    /// Resolve the loop to specify what this `CellLoop` was a forward
+    /// reference to.
+    ///
+    /// This function must be invoked in the same transaction as the
+    /// place where the `CellLoop` was created. This requires creating
+    /// an explicit transaction, either with
+    /// [`SodiumCtx::transaction`] or
+    /// [`Transaction::new`][crate::Transaction::new].
     pub fn loop_(&self, ca: &Cell<A>) {
         self.impl_.loop_(&ca.impl_);
     }

--- a/src/cell_loop.rs
+++ b/src/cell_loop.rs
@@ -2,6 +2,13 @@ use crate::impl_::cell_loop::CellLoop as CellLoopImpl;
 use crate::Cell;
 use crate::SodiumCtx;
 
+/// A forward reference for a [`Cell`] for creating dependency loops.
+///
+/// Both the creation of a `CellLoop` and filling it with the
+/// referenced [`Cell`] by calling [`loop_`][CellLoop::loop_] _must_
+/// occur within the same transaction, whether that is created by
+/// calling [`SodiumCtx::transaction`] or
+/// [`Transaction::new`][crate::Transaction::new].
 pub struct CellLoop<A> {
     impl_: CellLoopImpl<A>,
 }

--- a/src/cell_sink.rs
+++ b/src/cell_sink.rs
@@ -3,7 +3,7 @@ use crate::impl_::cell_sink::CellSink as CellSinkImpl;
 use crate::sodium_ctx::SodiumCtx;
 
 /// A [`Cell`] that allows values to be pushed into it, acting as a
-/// bridge between the world of I/O and the world of FRP.
+/// interface between the world of I/O and the world of FRP.
 ///
 /// ## Note: This should only be used from _outside_ the context of
 /// the Sodium system to inject data from I/O into the reactive system.
@@ -20,18 +20,30 @@ impl<A> Clone for CellSink<A> {
 }
 
 impl<A: Clone + Send + 'static> CellSink<A> {
+    /// Create a new `CellSink` in the given context.
     pub fn new(sodium_ctx: &SodiumCtx, a: A) -> CellSink<A> {
         CellSink {
             impl_: CellSinkImpl::new(&sodium_ctx.impl_, a),
         }
     }
 
+    /// Return a [`Cell`] that can be used to create Sodium logic that
+    /// will read the values pushed into this `CellSink` from the I/O
+    /// world.
     pub fn cell(&self) -> Cell<A> {
         Cell {
             impl_: self.impl_.cell(),
         }
     }
 
+    /// Send a value, modifying the value of the cell.
+    ///
+    /// This method may not be called in handlers registered with
+    /// [`Stream::listen`][crate::Stream::listen] or [`Cell::listen`].
+    ///
+    /// `CellSink` is an operational primitive, meant for interfacing
+    /// I/O to FRP only. You aren't meant to use this to define your
+    /// own primitives.
     pub fn send(&self, a: A) {
         self.impl_.send(a);
     }

--- a/src/cell_sink.rs
+++ b/src/cell_sink.rs
@@ -2,6 +2,11 @@ use crate::cell::Cell;
 use crate::impl_::cell_sink::CellSink as CellSinkImpl;
 use crate::sodium_ctx::SodiumCtx;
 
+/// A [`Cell`] that allows values to be pushed into it, acting as a
+/// bridge between the world of I/O and the world of FRP.
+///
+/// ## Note: This should only be used from _outside_ the context of
+/// the Sodium system to inject data from I/O into the reactive system.
 pub struct CellSink<A> {
     pub impl_: CellSinkImpl<A>,
 }

--- a/src/impl_/lambda.rs
+++ b/src/impl_/lambda.rs
@@ -31,31 +31,37 @@ pub fn lambda6_deps<A, B, C, D, E, F, G, FN: IsLambda6<A, B, C, D, E, F, G>>(f: 
     f.deps_op().cloned().unwrap_or_else(Vec::new)
 }
 
+/// Interface for a lambda function of one argument.
 pub trait IsLambda1<A, B> {
     fn call(&mut self, a: &A) -> B;
     fn deps_op(&self) -> Option<&Vec<Dep>>;
 }
 
+/// Interface for a lambda function of two arguments.
 pub trait IsLambda2<A, B, C> {
     fn call(&mut self, a: &A, b: &B) -> C;
     fn deps_op(&self) -> Option<&Vec<Dep>>;
 }
 
+/// Interface for a lambda function of three arguments.
 pub trait IsLambda3<A, B, C, D> {
     fn call(&mut self, a: &A, b: &B, c: &C) -> D;
     fn deps_op(&self) -> Option<&Vec<Dep>>;
 }
 
+/// Interface for a lambda function of four arguments.
 pub trait IsLambda4<A, B, C, D, E> {
     fn call(&mut self, a: &A, b: &B, c: &C, d: &D) -> E;
     fn deps_op(&self) -> Option<&Vec<Dep>>;
 }
 
+/// Interface for a lambda function of five arguments.
 pub trait IsLambda5<A, B, C, D, E, F> {
     fn call(&mut self, a: &A, b: &B, c: &C, d: &D, e: &E) -> F;
     fn deps_op(&self) -> Option<&Vec<Dep>>;
 }
 
+/// Interface for a lambda function of six arguments.
 pub trait IsLambda6<A, B, C, D, E, F, G> {
     fn call(&mut self, a: &A, b: &B, c: &C, d: &D, e: &E, f: &F) -> G;
     fn deps_op(&self) -> Option<&Vec<Dep>>;

--- a/src/impl_/lazy.rs
+++ b/src/impl_/lazy.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 use std::sync::Mutex;
 
+/// A representation for a value that may not be available until the
+/// current transaction is closed.
 pub struct Lazy<A> {
     data: Arc<Mutex<LazyData<A>>>,
 }

--- a/src/impl_/lazy.rs
+++ b/src/impl_/lazy.rs
@@ -21,18 +21,24 @@ pub enum LazyData<A> {
 }
 
 impl<A: Send + Clone + 'static> Lazy<A> {
+    /// Create a new `Lazy` whose value will be computed with the
+    /// given function sometime after the end of the current
+    /// transaction.
     pub fn new<THUNK: FnMut() -> A + Send + 'static>(thunk: THUNK) -> Lazy<A> {
         Lazy {
             data: Arc::new(Mutex::new(LazyData::Thunk(Box::new(thunk)))),
         }
     }
 
+    /// Create a new immediately ready `Lazy` value from the given value.
     pub fn of_value(value: A) -> Lazy<A> {
         Lazy {
             data: Arc::new(Mutex::new(LazyData::Value(value))),
         }
     }
 
+    /// Retrieve the value of this `Lazy` either by running the
+    /// supplied function or returning the already computed value.
     pub fn run(&self) -> A {
         let mut l = self.data.lock();
         let data: &mut LazyData<A> = l.as_mut().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+//! Sodium is a library for doing Functional Reactive Programming
+//! (FRP) in Rust.
 #![allow(clippy::mutable_key_type)]
 #[macro_use]
 extern crate log;
@@ -18,12 +20,19 @@ mod transaction;
 pub use self::cell::Cell;
 pub use self::cell_loop::CellLoop;
 pub use self::cell_sink::CellSink;
+#[doc(hidden)]
 pub use self::impl_::dep::Dep;
+#[doc(hidden)]
 pub use self::impl_::lambda::lambda1;
+#[doc(hidden)]
 pub use self::impl_::lambda::lambda2;
+#[doc(hidden)]
 pub use self::impl_::lambda::lambda3;
+#[doc(hidden)]
 pub use self::impl_::lambda::lambda4;
+#[doc(hidden)]
 pub use self::impl_::lambda::lambda5;
+#[doc(hidden)]
 pub use self::impl_::lambda::lambda6;
 pub use self::impl_::lambda::IsLambda1;
 pub use self::impl_::lambda::IsLambda2;
@@ -31,8 +40,10 @@ pub use self::impl_::lambda::IsLambda3;
 pub use self::impl_::lambda::IsLambda4;
 pub use self::impl_::lambda::IsLambda5;
 pub use self::impl_::lambda::IsLambda6;
+#[doc(hidden)]
 pub use self::impl_::lambda::Lambda;
 pub use self::impl_::lazy::Lazy;
+#[doc(hidden)]
 pub use self::impl_::node::Node;
 pub use self::listener::Listener;
 pub use self::operational::Operational;

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -7,6 +7,9 @@ pub struct Listener {
 }
 
 impl Listener {
+    /// Deregister the listener that was registered so it will no
+    /// longer be called back, allowing associated resources to be
+    /// garbage-collected.
     pub fn unlisten(&self) {
         self.impl_.unlisten();
     }

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,5 +1,7 @@
 use crate::impl_::listener::Listener as ListenerImpl;
 
+/// A handle for a listener registered on some [`Cell`][crate::Cell]
+/// or [`Stream`][crate::Stream].
 pub struct Listener {
     pub impl_: ListenerImpl,
 }

--- a/src/operational.rs
+++ b/src/operational.rs
@@ -1,6 +1,8 @@
 use crate::Cell;
 use crate::Stream;
 
+/// Operational primitives that must be used with care because they
+/// break non-detectability of `Cell` steps/updates.
 pub struct Operational {}
 
 impl Operational {

--- a/src/router.rs
+++ b/src/router.rs
@@ -3,11 +3,16 @@ use crate::SodiumCtx;
 use crate::Stream;
 use std::hash::Hash;
 
+/// Create a new Router that routes event items of type `A` to zero or
+/// more [`Stream`]s of type `K` according to a given selector
+/// function.
 pub struct Router<A, K> {
     impl_: RouterImpl<A, K>,
 }
 
 impl<A, K> Router<A, K> {
+    /// Create a new `Router` from the given input stream and selector
+    /// function.
     pub fn new(
         sodium_ctx: &SodiumCtx,
         in_stream: &Stream<A>,
@@ -22,6 +27,8 @@ impl<A, K> Router<A, K> {
         }
     }
 
+    /// Create a Stream that is subscribed to event values that the
+    /// selector function routes to the given `K` value.
     pub fn filter_matches(&self, k: &K) -> Stream<A>
     where
         A: Clone + Send + 'static,

--- a/src/sodium_ctx.rs
+++ b/src/sodium_ctx.rs
@@ -23,36 +23,48 @@ impl Default for SodiumCtx {
 }
 
 impl SodiumCtx {
+    /// Create a new Sodium FRP context.
     pub fn new() -> SodiumCtx {
         SodiumCtx {
             impl_: SodiumCtxImpl::new(),
         }
     }
 
+    /// Create a new constant value [`Cell`] in this context.
     pub fn new_cell<A: Clone + Send + 'static>(&self, a: A) -> Cell<A> {
         Cell::new(self, a)
     }
 
+    /// Create a new stream that will never fire in this context.
     pub fn new_stream<A: Clone + Send + 'static>(&self) -> Stream<A> {
         Stream::new(self)
     }
 
+    /// Create a new [`CellSink`] for interfacing I/O and FRP.
     pub fn new_cell_sink<A: Clone + Send + 'static>(&self, a: A) -> CellSink<A> {
         CellSink::new(self, a)
     }
 
+    /// Create a new [`StreamSink`] for interfacing I/O and FRP.
     pub fn new_stream_sink<A: Clone + Send + 'static>(&self) -> StreamSink<A> {
         StreamSink::new(self)
     }
 
+    /// Create a new [`CellLoop`] to act as a forward reference for a
+    /// [`Cell`] that will be created later.
     pub fn new_cell_loop<A: Clone + Send + 'static>(&self) -> CellLoop<A> {
         CellLoop::new(self)
     }
 
+    /// Create a new [`StreamLoop`] to act as a forward reference for
+    /// a [`Stream`] that will be created later.
     pub fn new_stream_loop<A: Clone + Send + 'static>(&self) -> StreamLoop<A> {
         StreamLoop::new(self)
     }
 
+    /// Create a new [`StreamSink`] with a combining function that
+    /// allows [`send`][CellSink::send]ing multiple event values per
+    /// transaction.
     pub fn new_stream_sink_with_coalescer<
         A: Clone + Send + 'static,
         COALESCER: FnMut(&A, &A) -> A + Send + 'static,
@@ -63,18 +75,28 @@ impl SodiumCtx {
         StreamSink::new_with_coalescer(self, coalescer)
     }
 
+    /// Run the given function inside a single Sodium transaction,
+    /// closing the transaction after the function returns.
     pub fn transaction<R, K: FnOnce() -> R>(&self, k: K) -> R {
         self.impl_.transaction(k)
     }
 
+    /// Create a new scoped transaction object.
+    ///
+    /// The Sodium transaction on this context will be held open until
+    /// the returned [`Transaction`] is dropped or
+    /// [Transaction::close] is called explicitly.
     pub fn new_transaction(&self) -> Transaction {
         Transaction::new(self)
     }
 
+    /// Execute the given code after the current transaction is
+    /// closed, or immediately if there is no current transaction.
     pub fn post<K: FnMut() + Send + 'static>(&self, k: K) {
         self.impl_.post(k);
     }
 
+    /// Create a new [`Router`] in this context.
     pub fn new_router<A, K>(
         &self,
         in_stream: &Stream<A>,

--- a/src/sodium_ctx.rs
+++ b/src/sodium_ctx.rs
@@ -9,6 +9,8 @@ use crate::StreamSink;
 use crate::Transaction;
 use std::hash::Hash;
 
+/// A context object representing a specific instance of a Sodium
+/// system.
 #[derive(Clone)]
 pub struct SodiumCtx {
     pub impl_: SodiumCtxImpl,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -7,6 +7,12 @@ use crate::listener::Listener;
 use crate::sodium_ctx::SodiumCtx;
 use crate::Lazy;
 
+/// Represents a stream of discrete events/firings containing values
+/// of type `A`.
+///
+/// Also known in other FRP systems as an _event_ (which would contain
+/// _event occurrences_), an _event stream_, an _observable_, or a
+/// _signal_.
 pub struct Stream<A> {
     pub impl_: StreamImpl<A>,
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -26,6 +26,9 @@ impl<A> Clone for Stream<A> {
 }
 
 impl<A: Clone + Send + 'static> Stream<Option<A>> {
+    /// Return a `Stream` that only outputs events that have present
+    /// values, removing the `Option` wrapper and discarding empty
+    /// values.
     pub fn filter_option(&self) -> Stream<A> {
         self.filter(|a: &Option<A>| a.is_some())
             .map(|a: &Option<A>| a.clone().unwrap())
@@ -38,6 +41,8 @@ impl<
         COLLECTION: IntoIterator<Item = A> + Clone + Send + 'static,
     > Stream<COLLECTION>
 {
+    /// Flatten a `Stream` of a collection of `A` into a `Stream` of
+    /// single `A`s.
     pub fn split(&self) -> Stream<A> {
         Stream {
             impl_: self.impl_.split(),
@@ -46,17 +51,29 @@ impl<
 }
 
 impl<A: Clone + Send + 'static> Stream<A> {
+    /// Create a `Stream` that will never fire.
     pub fn new(sodium_ctx: &SodiumCtx) -> Stream<A> {
         Stream {
             impl_: StreamImpl::new(&sodium_ctx.impl_),
         }
     }
 
+    #[doc(hidden)]
     // use as dependency to lambda1, lambda2, etc.
     pub fn to_dep(&self) -> Dep {
         self.impl_.to_dep()
     }
 
+    /// Return a stream whose events are the result of the combination
+    /// of the event value and the current value of the cell using the
+    /// specified function.
+    ///
+    /// Note that there is an implicit delay: state updates caused by
+    /// event firings being held with [`Stream::hold`] don't become
+    /// visible as the cell's current value until the following
+    /// transaction. To put this another way, `snapshot` always sees
+    /// the value of a cell as it wass before any state changes from
+    /// the current transaction.
     pub fn snapshot<
         B: Clone + Send + 'static,
         C: Clone + Send + 'static,
@@ -71,10 +88,15 @@ impl<A: Clone + Send + 'static> Stream<A> {
         }
     }
 
+    /// A variant of [`snapshot`][Stream::snapshot] that captures the
+    /// cell's value at the time of the event firing, ignoring the
+    /// stream's value.
     pub fn snapshot1<B: Send + Clone + 'static>(&self, cb: &Cell<B>) -> Stream<B> {
         self.snapshot(cb, |_a: &A, b: &B| b.clone())
     }
 
+    /// A variant of [`snapshot`][Stream::snapshot] that captures the
+    /// value of two cells.
     pub fn snapshot3<
         B: Send + Clone + 'static,
         C: Send + Clone + 'static,
@@ -100,6 +122,8 @@ impl<A: Clone + Send + 'static> Stream<A> {
         )
     }
 
+    /// A variant of [`snapshot`][Stream::snapshot] that captures the
+    /// value of three cells.
     pub fn snapshot4<
         B: Send + Clone + 'static,
         C: Send + Clone + 'static,
@@ -132,6 +156,8 @@ impl<A: Clone + Send + 'static> Stream<A> {
         )
     }
 
+    /// A variant of [`snapshot`][Stream::snapshot] that captures the
+    /// value of four cells.
     pub fn snapshot5<
         B: Send + Clone + 'static,
         C: Send + Clone + 'static,
@@ -168,6 +194,8 @@ impl<A: Clone + Send + 'static> Stream<A> {
         )
     }
 
+    /// A variant of [`snapshot`][Stream::snapshot] that captures the
+    /// value of five cells.
     pub fn snapshot6<
         B: Send + Clone + 'static,
         C: Send + Clone + 'static,
@@ -210,6 +238,13 @@ impl<A: Clone + Send + 'static> Stream<A> {
         )
     }
 
+    /// Transform this `Stream`'s event values with the supplied
+    /// function.
+    ///
+    /// The supplied function may construct FRP logic or use
+    /// [`Cell::sample`], in which case it's equivalent to
+    /// [`snapshot`][Stream::snapshot]ing the cell. In addition, the
+    /// function must be referentially transparent.
     pub fn map<B: Send + Clone + 'static, FN: IsLambda1<A, B> + Send + Sync + 'static>(
         &self,
         f: FN,
@@ -219,10 +254,12 @@ impl<A: Clone + Send + 'static> Stream<A> {
         }
     }
 
+    /// Transform this `Stream`'s event values into the specified constant value.
     pub fn map_to<B: Send + Sync + Clone + 'static>(&self, b: B) -> Stream<B> {
         self.map(move |_: &A| b.clone())
     }
 
+    /// Return a `Stream` that only outputs events for which the predicate returns `true`.
     pub fn filter<PRED: IsLambda1<A, bool> + Send + Sync + 'static>(
         &self,
         pred: PRED,
@@ -232,10 +269,31 @@ impl<A: Clone + Send + 'static> Stream<A> {
         }
     }
 
+    /// Variant of [`merge`][Stream::merge] that merges two streams.
+    ///
+    /// In the case where two events are simultaneous (both in the
+    /// same transaction), the event taken from `self` takes
+    /// precedenc, and the event from `s2` will be dropped.
+    ///
+    /// If you want to specify your own combining function use
+    /// [`merge`][Stream::merge]. This function is equivalent to
+    /// `s1.merge(s2, |l, _r| l)`. The name `or_else` is used instead
+    /// of `merge` to make it clear that care should be taken because
+    /// events can be dropped.
     pub fn or_else(&self, s2: &Stream<A>) -> Stream<A> {
         self.merge(s2, |lhs: &A, _rhs: &A| lhs.clone())
     }
 
+    /// Merge two streams of the same type into one, so that events on
+    /// either input appear on the returned stream.
+    ///
+    /// If the events are simultaneous (that is, one event from `self`
+    /// and one from `s2` occur in the same transaction), combine them
+    /// into one using the specified combining function so that the
+    /// returned stream is guaranteed only ever to have one event per
+    /// transaction. The event from `self` will appear at the left
+    /// input of the combining function, and the event from `s2` will
+    /// appear at the right.
     pub fn merge<FN: IsLambda2<A, A, A> + Send + Sync + 'static>(
         &self,
         s2: &Stream<A>,
@@ -246,30 +304,42 @@ impl<A: Clone + Send + 'static> Stream<A> {
         }
     }
 
+    /// Returns a cell with the specified initial value, which is
+    /// updated by this stream's event values.
     pub fn hold(&self, a: A) -> Cell<A> {
         Cell {
             impl_: self.impl_.hold(a),
         }
     }
 
+    /// A variant of [`hold`][Stream::hold] that uses an initial value
+    /// returned by [`Cell::sample_lazy`].
     pub fn hold_lazy(&self, a: Lazy<A>) -> Cell<A> {
         Cell {
             impl_: self.impl_.hold_lazy(a),
         }
     }
 
+    /// Return a stream that only outputs events from the input stream
+    /// when the specified cell's value is true.
     pub fn gate(&self, cpred: &Cell<bool>) -> Stream<A> {
         let cpred = cpred.clone();
         let cpred_dep = cpred.to_dep();
         self.filter(lambda1(move |_: &A| cpred.sample(), vec![cpred_dep]))
     }
 
+    /// Return a stream that outputs only one value, which is the next
+    /// event of the input stream, starting from the transaction in
+    /// `once` was invoked.
     pub fn once(&self) -> Stream<A> {
         Stream {
             impl_: self.impl_.once(),
         }
     }
 
+    /// Transform an event with a generalized state loop (a Mealy
+    /// machine). The function is passed the input and the old state
+    /// and returns the new state and output value.
     pub fn collect<B, S, F>(&self, init_state: S, f: F) -> Stream<B>
     where
         B: Send + Clone + 'static,
@@ -279,6 +349,8 @@ impl<A: Clone + Send + 'static> Stream<A> {
         self.collect_lazy(Lazy::new(move || init_state.clone()), f)
     }
 
+    /// A variant of [`collect`][Stream::collect] that takes an
+    /// initial state that is returned by [`Cell::sample_lazy`].
     pub fn collect_lazy<B, S, F>(&self, init_state: Lazy<S>, f: F) -> Stream<B>
     where
         B: Send + Clone + 'static,
@@ -290,6 +362,14 @@ impl<A: Clone + Send + 'static> Stream<A> {
         }
     }
 
+    /// Accumulate on an input event, outputting the new state each time.
+    ///
+    /// As each event is received, the accumulating function `f` is
+    /// called with the current state and the new event value. The
+    /// accumulating function may construct FRP logic or use
+    /// [`Cell::sample`], in which case it's equivalent to
+    /// [`snapshot`][Stream::snapshot]ing the cell. In additon, the
+    /// function must be referentially transparent.
     pub fn accum<S, F>(&self, init_state: S, f: F) -> Cell<S>
     where
         S: Send + Clone + 'static,
@@ -298,6 +378,8 @@ impl<A: Clone + Send + 'static> Stream<A> {
         self.accum_lazy(Lazy::new(move || init_state.clone()), f)
     }
 
+    /// A variant of [`accum`][Stream::accum] that takes an initial
+    /// state returned by [`Cell::sample_lazy`].
     pub fn accum_lazy<S, F>(&self, init_state: Lazy<S>, f: F) -> Cell<S>
     where
         S: Send + Clone + 'static,
@@ -308,12 +390,30 @@ impl<A: Clone + Send + 'static> Stream<A> {
         }
     }
 
+    /// A variant of [`listen`][Stream::listen] that will deregister
+    /// the listener automatically if the listener is
+    /// garbage-collected.
+    ///
+    /// With [`listen`][Stream::listen] the listener is only
+    /// deregistered if [`Listener::unlisten`] is called explicitly.
     pub fn listen_weak<K: IsLambda1<A, ()> + Send + Sync + 'static>(&self, k: K) -> Listener {
         Listener {
             impl_: self.impl_.listen_weak(k),
         }
     }
 
+    /// Listen for events/firings on this stream.
+    ///
+    /// This is the observer pattern. The returned [`Listener`] has an
+    /// [`unlisten`][Listener::unlisten] method to cause the listener
+    /// to be removed. This is an operational mechanism for
+    /// interfacing between the world of I/O and FRP.
+    ///
+    /// The handler function for this listener should make no
+    /// assumptions about what thread it will be called on, and the
+    /// handler should not block. It also is not allowed to use
+    /// [`CellSink::send`][crate::CellSink::send] or
+    /// [`StreamSink::send`][crate::StreamSink::send] in the handler.
     pub fn listen<K: IsLambda1<A, ()> + Send + Sync + 'static>(&self, k: K) -> Listener {
         Listener {
             impl_: self.impl_.listen(k),

--- a/src/stream_loop.rs
+++ b/src/stream_loop.rs
@@ -8,18 +8,30 @@ pub struct StreamLoop<A> {
 }
 
 impl<A: Send + Clone + 'static> StreamLoop<A> {
+    /// Create a new `StreamLoop` in the given context.
     pub fn new(sodium_ctx: &SodiumCtx) -> StreamLoop<A> {
         StreamLoop {
             impl_: StreamLoopImpl::new(&sodium_ctx.impl_),
         }
     }
 
+    /// Return a [`Stream`] that is equivalent to this `StreamLoop`
+    /// once it has been resolved by calling
+    /// [`loop_`][StreamLoop::loop_].
     pub fn stream(&self) -> Stream<A> {
         Stream {
             impl_: self.impl_.stream(),
         }
     }
 
+    /// Resolve the loop to specify what this `StreamLoop` was a
+    /// forward reference to.
+    ///
+    /// This function _must_ be invoked in the same transaction as the
+    /// place where the `StreamLoop` is used. This requires you to
+    /// create an explicit transaction, either with
+    /// [`SodiumCtx::transaction`] or
+    /// [`Transaction::new`][crate::Transaction::new].
     pub fn loop_(&self, sa: &Stream<A>) {
         self.impl_.loop_(&sa.impl_);
     }

--- a/src/stream_loop.rs
+++ b/src/stream_loop.rs
@@ -2,6 +2,7 @@ use crate::impl_::stream_loop::StreamLoop as StreamLoopImpl;
 use crate::SodiumCtx;
 use crate::Stream;
 
+/// A forward reference of a [`Stream`] for creating dependency loops.
 pub struct StreamLoop<A> {
     pub impl_: StreamLoopImpl<A>,
 }

--- a/src/stream_sink.rs
+++ b/src/stream_sink.rs
@@ -2,8 +2,8 @@ use crate::impl_::stream_sink::StreamSink as StreamSinkImpl;
 use crate::sodium_ctx::SodiumCtx;
 use crate::stream::Stream;
 
-/// A [`Stream`] that allows values to be pushed into it, acting as a
-/// bridge between the world of I/O and the world of FRP.
+/// A [`Stream`] that allows values to be pushed into it, acting as an
+/// interface between the world of I/O and the world of FRP.
 ///
 /// ## Note: This should only be used from _outside_ the context of
 /// the Sodium system to inject data from I/O into the reactive system.
@@ -20,12 +20,26 @@ impl<A> Clone for StreamSink<A> {
 }
 
 impl<A: Clone + Send + 'static> StreamSink<A> {
+    /// Create a `StreamSink` that allows calling `send` on it once
+    /// per transaction.
+    ///
+    /// If you call `send` more than once in a transaction on a
+    /// `StreamSink` constructed with `StreamSink::new` it will
+    /// panic. If you need to do this then use
+    /// [`StreamSink::new_with_coalescer`].
     pub fn new(sodium_ctx: &SodiumCtx) -> StreamSink<A> {
         StreamSink {
             impl_: StreamSinkImpl::new(&sodium_ctx.impl_),
         }
     }
 
+    /// Create a `StreamSink` that allows calling `send` one or more
+    /// times per transaction.
+    ///
+    /// If you call `send` on the returned `StreamSink` more than once
+    /// in a single transaction the events will be combined into a
+    /// single event using the specified combining function. The
+    /// combining function should be _associative_.
     pub fn new_with_coalescer<COALESCER: FnMut(&A, &A) -> A + Send + 'static>(
         sodium_ctx: &SodiumCtx,
         coalescer: COALESCER,
@@ -35,12 +49,20 @@ impl<A: Clone + Send + 'static> StreamSink<A> {
         }
     }
 
+    /// Return a [`Stream`] that can be used in the creation of Sodium
+    /// logic that will consume events pushed into this `StreamSink`
+    /// from the I/O world.
     pub fn stream(&self) -> Stream<A> {
         Stream {
             impl_: self.impl_.stream(),
         }
     }
 
+    /// Send a value to be made available to consumers of the `Stream`
+    /// associated with this `StreamSink`.
+    ///
+    /// This method may not be called in handlers registered with
+    /// [`Stream::listen`] or [`Cell::listen`][crate::Cell::listen].
     pub fn send(&self, a: A) {
         self.impl_.send(a);
     }

--- a/src/stream_sink.rs
+++ b/src/stream_sink.rs
@@ -2,6 +2,11 @@ use crate::impl_::stream_sink::StreamSink as StreamSinkImpl;
 use crate::sodium_ctx::SodiumCtx;
 use crate::stream::Stream;
 
+/// A [`Stream`] that allows values to be pushed into it, acting as a
+/// bridge between the world of I/O and the world of FRP.
+///
+/// ## Note: This should only be used from _outside_ the context of
+/// the Sodium system to inject data from I/O into the reactive system.
 pub struct StreamSink<A> {
     pub impl_: StreamSinkImpl<A>,
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -11,13 +11,18 @@ pub struct Transaction {
 }
 
 impl Transaction {
+    /// Create a new scoped transaction on the given context.
     pub fn new(sodium_ctx: &SodiumCtx) -> Transaction {
         Transaction {
             impl_: TransactionImpl::new(&sodium_ctx.impl_),
         }
     }
 
-    // optional earily close
+    /// Explicitly close this transaction.
+    ///
+    /// This transaction will close automatically when it goes out of
+    /// scope and is dropped. This `close` method is an optional way
+    /// to explicitly close the transaction before that.
     pub fn close(&self) {
         self.impl_.close();
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,6 +1,11 @@
 use crate::impl_::transaction::Transaction as TransactionImpl;
 use crate::SodiumCtx;
 
+/// A scoped transaction marker.
+///
+/// An alternative to [`SodiumCtx::transaction`] that creates a struct
+/// that will create a new transaction in the given [`SodiumCtx`] and
+/// hold it open until the `Transaction` is dropped.
 pub struct Transaction {
     impl_: TransactionImpl,
 }


### PR DESCRIPTION
Most of the documentation was taken directly from Appendix A of the "Functional Reactive Programming" book and slightly adjusted to match the Rust semantics and documentation conventions.

Since the C++ API documented in that appendix is missing a few things present in the Rust API I had to write the documentation for those items from scratch. Extra scrutiny to those items would be appreciated to ensure their correctness.  This includes:

- All `SodiumCtx` docs
- All `Router` docs
- The `CellSink::cell` method docs
- The `StreamSink::stream` method docs

I'm particularly vague on exactly what `Router` does, not having used it personally, though the type signature does seem to describe it fairly well.

In addition I hid the documentation for several things that are only incidentally public and not actually intended to be used by library consumers.

This is just a first pass of documentation for the crate. I intend to come back and add more exposition on the crate root and the documentation on each type, eventually including example code.